### PR TITLE
Fix proxy configuration helpers and refresh docs

### DIFF
--- a/simple_snowplow/main.py
+++ b/simple_snowplow/main.py
@@ -58,15 +58,6 @@ def create_app() -> FastAPI:
         ],
     )
 
-    app.add_middleware(
-        CORSMiddleware,
-        allow_origin_regex=".*",
-        allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
-        expose_headers=["*"],
-    )
-
     # Add conditional middleware
     if settings.security.enable_https_redirect:
         app.add_middleware(HTTPSRedirectMiddleware)

--- a/simple_snowplow/routers/proxy/__init__.py
+++ b/simple_snowplow/routers/proxy/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 
 import requests
@@ -16,11 +18,11 @@ router = APIRouter(tags=["proxy"], prefix=PROXY_ENDPOINT)
 
 
 def encode(s: str) -> str:
-    return base64.b64encode(s.encode("ascii"), altchars=b"+_").decode("utf-8")
+    return base64.urlsafe_b64encode(s.encode("utf-8")).decode("utf-8")
 
 
 def decode(s: str) -> str:
-    return base64.urlsafe_b64decode(s).decode("UTF-8")
+    return base64.urlsafe_b64decode(s).decode("utf-8")
 
 
 @router.post("/hash")


### PR DESCRIPTION
## Summary
- import the modules required by the proxy router and use url-safe base64 helpers
- remove the duplicate CORS middleware registration in the FastAPI app factory
- refresh the README to document the environment-variable based configuration and CLI usage accurately

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68ceb46a383083289755a616140f2a90