### PR TITLE
Use async HTTP client for proxy requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fastapi>=0.115.12",
     "fastapi-structlog>=0.5.0",
     "fire>=0.7.0",
+    "httpx>=0.28.1",
     "inflection>=0.5.1",
     "json-repair>=0.44.0",
     "orjson>=3.10.16",

--- a/simple_snowplow/routers/proxy/__init__.py
+++ b/simple_snowplow/routers/proxy/__init__.py
@@ -61,7 +61,7 @@ async def proxy(schema: str, host: str, path: str = ""):
     url = f"{schema}://{decode(host)}/{decode(path)}"
 
     try:
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(follow_redirects=True) as client:
             response = await client.get(url, timeout=PROXY_TIMEOUT)
     except httpx.TimeoutException as exc:
         msg = f"Proxy request to '{url}' timed out"

--- a/simple_snowplow/routers/proxy/__init__.py
+++ b/simple_snowplow/routers/proxy/__init__.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import base64
+from typing import Final
 
-import requests
+import httpx
 from core.config import settings
+from fastapi import HTTPException
 from fastapi.responses import Response
 from fastapi.routing import APIRouter
 
@@ -12,6 +14,7 @@ from routers.proxy import models
 PROXY_CONFIG = settings.proxy
 PROXY_ENDPOINT = settings.common.snowplow.endpoints.proxy_endpoint
 HOSTNAME = settings.common.hostname
+PROXY_TIMEOUT: Final[float] = 10.0
 
 
 router = APIRouter(tags=["proxy"], prefix=PROXY_ENDPOINT)
@@ -57,11 +60,18 @@ async def proxy_hash(data: models.HashModel):
 async def proxy(schema: str, host: str, path: str = ""):
     url = f"{schema}://{decode(host)}/{decode(path)}"
 
-    r = requests.get(url)
-    content = r.content
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, timeout=PROXY_TIMEOUT)
+    except httpx.TimeoutException as exc:
+        msg = f"Proxy request to '{url}' timed out"
+        raise HTTPException(status_code=504, detail=msg) from exc
+    except httpx.RequestError as exc:  # pragma: no cover - specific network errors
+        msg = f"Proxy request to '{url}' failed"
+        raise HTTPException(status_code=502, detail=msg) from exc
 
     return Response(
-        content=content,
-        status_code=r.status_code,
-        media_type=r.headers["Content-Type"],
+        content=response.content,
+        status_code=response.status_code,
+        media_type=response.headers.get("Content-Type", "application/octet-stream"),
     )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,54 @@
+import asyncio
+import pathlib
+import sys
+
+import pytest
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(PROJECT_ROOT))
+sys.path.append(str(PROJECT_ROOT / "simple_snowplow"))
+
+from simple_snowplow.routers import proxy as proxy_module
+
+
+class _DummyResponse:
+    status_code = 200
+    content = b"ok"
+    headers = {"Content-Type": "text/plain"}
+
+
+class _DummyAsyncClient:
+    def __init__(self, event: asyncio.Event):
+        self._event = event
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url: str, timeout: float):
+        await asyncio.sleep(0)
+        self._event.set()
+        return _DummyResponse()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_proxy_awaits_async_request(monkeypatch, anyio_backend):
+    event = asyncio.Event()
+
+    def _factory(*args, **kwargs):
+        return _DummyAsyncClient(event)
+
+    monkeypatch.setattr(proxy_module.httpx, "AsyncClient", _factory)
+
+    response = await proxy_module.proxy(
+        "https",
+        proxy_module.encode("example.com"),
+        proxy_module.encode("tracker"),
+    )
+
+    assert event.is_set(), "Proxy did not await the HTTP request"
+    assert response.status_code == 200
+    assert response.body == b"ok"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -39,6 +39,7 @@ async def test_proxy_awaits_async_request(monkeypatch, anyio_backend):
     event = asyncio.Event()
 
     def _factory(*args, **kwargs):
+        assert kwargs.get("follow_redirects") is True
         return _DummyAsyncClient(event)
 
     monkeypatch.setattr(proxy_module.httpx, "AsyncClient", _factory)


### PR DESCRIPTION
## Summary
- switch the proxy router to use httpx.AsyncClient with a timeout and graceful HTTP errors
- add httpx as an application dependency
- add an async pytest that verifies the proxy awaits the upstream request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ceb7f12b3c8328ba9c0e52d1ce2153