### PR TITLE
fix: address FastAPI review findings (security, async, worker reliabi…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,52 @@
+# evnt example environment file
+#
+# Copy to `.env` and adjust. All settings use the EVNT_ prefix; nested keys use
+# a double underscore (__). List/dict values are JSON. Run
+# `uv run python evnt/cli.py settings` to inspect the full resolved config.
+#
+# NOTE: these are example values only — never commit real secrets.
+
+# --- Common ---
+EVNT_COMMON__DEMO=false                 # enable the /demo/ SPA (true in compose.yml)
+EVNT_COMMON__DEBUG=false
+# EVNT_ENV=production                    # set to "production" in prod
+
+# --- Logging ---
+EVNT_LOGGING__LEVEL=WARNING             # DEBUG|INFO|WARNING|ERROR|CRITICAL
+EVNT_LOGGING__JSON_FORMAT=false
+
+# --- Security (safe defaults) ---
+EVNT_SECURITY__DISABLE_DOCS=true        # set false to expose /docs, /redoc, /openapi.json
+EVNT_SECURITY__TRUSTED_HOSTS=["*"]
+EVNT_SECURITY__TRUST_PROXY_HEADERS=true # false if evnt is exposed without a trusted proxy
+EVNT_SECURITY__ENABLE_HTTPS_REDIRECT=false
+# CORS: use explicit origins; credentials + "*" is rejected at startup.
+EVNT_SECURITY__CORS_ALLOWED_ORIGINS=["*"]
+EVNT_SECURITY__CORS_ALLOW_CREDENTIALS=false
+# Credentialed pattern (uncomment together, never with "*"):
+# EVNT_SECURITY__CORS_ALLOWED_ORIGINS=["https://app.example.com"]
+# EVNT_SECURITY__CORS_ALLOW_CREDENTIALS=true
+
+# --- Analytics-script proxy (/proxy) ---
+EVNT_PROXY__DOMAINS=["google-analytics.com", "www.googletagmanager.com"]
+EVNT_PROXY__PATHS=["analytics.js", "gtm.js"]
+EVNT_PROXY__ALLOWED_PORTS=[80, 443]     # outbound ports allowed on allowlisted hosts
+
+# --- ClickHouse ---
+EVNT_CLICKHOUSE__CONNECTION__HOST=clickhouse
+EVNT_CLICKHOUSE__CONNECTION__PORT=8123
+EVNT_CLICKHOUSE__CONNECTION__USERNAME=default
+EVNT_CLICKHOUSE__CONNECTION__PASSWORD=change-me   # SecretStr; redacted in dumps/logs
+EVNT_CLICKHOUSE__CONNECTION__DATABASE=default
+EVNT_CLICKHOUSE__STARTUP_TIMEOUT_SECONDS=60
+
+# --- Ingest ---
+EVNT_INGEST__MODE=direct                # direct (default) | rabbitmq
+
+# --- RabbitMQ (only used when EVNT_INGEST__MODE=rabbitmq) ---
+EVNT_INGEST__RABBITMQ__HOST=rabbitmq
+EVNT_INGEST__RABBITMQ__PORT=5672
+EVNT_INGEST__RABBITMQ__USERNAME=guest
+EVNT_INGEST__RABBITMQ__PASSWORD=change-me          # SecretStr; redacted in dumps/logs
+EVNT_INGEST__RABBITMQ__QUEUE_NAME=evnt.ingest
+EVNT_INGEST__RABBITMQ__BATCH_SIZE=500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Security
+- **CORS hardened**: `EVNT_SECURITY__CORS_ALLOW_CREDENTIALS` now defaults to `false`. Combining credentials with the `["*"]` wildcard origin is rejected at startup, and credentials are never reflected for wildcard origins by the middleware. Use explicit origins (`EVNT_SECURITY__CORS_ALLOWED_ORIGINS`) to allow credentialed cross-origin requests.
+- **API docs disabled by default**: `EVNT_SECURITY__DISABLE_DOCS` now defaults to `true`, so `/docs`, `/redoc` and `/openapi.json` are off. Set it to `false` to re-enable.
+- **Proxy SSRF fixes**: the `/proxy` endpoint no longer auto-follows redirects (an allowlisted host could otherwise bounce it to an internal target), and a new `EVNT_PROXY__ALLOWED_PORTS` allowlist (default `[80, 443]`) restricts outbound ports so an attacker cannot append a port to reach internal services.
+- **Secrets redacted**: ClickHouse and RabbitMQ passwords are now `SecretStr`; their values are kept out of config dumps and logs while remaining env-configurable.
+- **Proxy-header trust enforced**: `EVNT_SECURITY__TRUST_PROXY_HEADERS` is now actually honored for client-IP extraction. Set it to `false` when `evnt` is exposed directly so clients cannot spoof their IP via `X-Forwarded-For`.
+- Dropped the deprecated `X-XSS-Protection` response header.
+
+### Reliability
+- Offloaded blocking work (jsonschema validation, user-agent parsing) to worker threads so per-request CPU work no longer blocks the event loop.
+- **RabbitMQ worker**: clean `SIGTERM` shutdown (final flush + close), capped exponential backoff moved out of the flush path into the run loop, publisher confirms on failed-queue publishes to prevent silent loss, and a liveness file consumed by a new `evnt queue healthcheck` (wired as the worker container `HEALTHCHECK` in `compose.yml`).
+- ClickHouse startup connection retry in the worker, matching the app lifespan.
+- Guarded untrusted UUID/datetime/dict-key access in the payload parser to avoid uncaught 500s.
+
+### Changed
+- `EVNT_SECURITY__DISABLE_DOCS` default `false` → `true`.
+- `EVNT_SECURITY__CORS_ALLOW_CREDENTIALS` default `true` → `false`.
+- ClickHouse/RabbitMQ password fields changed type to `SecretStr`.
+
+### Added
+- `EVNT_PROXY__ALLOWED_PORTS` (default `[80, 443]`) — outbound proxy port allowlist.
+- `evnt queue healthcheck` CLI command — liveness-aware health probe for the RabbitMQ worker.
+
 ## [v2.2.0] - 2025-05-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ That places `sp.js` (and plugins) into `evnt/static/`, served at `/static/sp.js`
 
 ## Configuration
 
-Settings are loaded from a single Pydantic `BaseSettings` model. Use the `EVNT_` prefix and `__` for nested keys:
+Settings are loaded from a single Pydantic `BaseSettings` model. Use the `EVNT_` prefix and `__` for nested keys. List/dict values are parsed as JSON:
 
 ```bash
 EVNT_COMMON__DEMO=true                          # enable the /demo/ SPA at runtime
@@ -78,6 +78,80 @@ Inspect the full config tree (with defaults) any time:
 ```bash
 uv run python evnt/cli.py settings
 ```
+
+A starter [`.env.example`](.env.example) lists the most common variables with safe defaults.
+
+### Security defaults
+
+`evnt` ships with safe-by-default settings. The most important ones to know about:
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `EVNT_SECURITY__DISABLE_DOCS` | `true` | `/docs`, `/redoc` and `/openapi.json` are **disabled**. Set to `false` to expose them. |
+| `EVNT_SECURITY__CORS_ALLOWED_ORIGINS` | `["*"]` | JSON array of bare HTTP(S) origins (e.g. `["https://example.com"]`), or `["*"]`. |
+| `EVNT_SECURITY__CORS_ALLOW_CREDENTIALS` | `false` | Cannot be combined with the `["*"]` wildcard — see below. |
+| `EVNT_SECURITY__TRUSTED_HOSTS` | `["*"]` | Allowed `Host` header values. |
+| `EVNT_SECURITY__TRUST_PROXY_HEADERS` | `true` | When enabled, the client IP is taken from the configured proxy header (`X-Forwarded-For` by default). Set to `false` if `evnt` is exposed directly (no trusted reverse proxy) so clients cannot spoof their IP. |
+| `EVNT_SECURITY__ENABLE_HTTPS_REDIRECT` | `false` | Adds an HSTS header and HTTPS redirect when enabled. |
+
+**Re-enabling the API docs.** Interactive docs are off by default. To turn them back on (e.g. for a private/staging instance):
+
+```bash
+EVNT_SECURITY__DISABLE_DOCS=false
+```
+
+**CORS with credentials.** Browser credentials (cookies, `Authorization`) are **never** reflected for wildcard origins. To allow credentialed cross-origin requests you must list explicit origins — combining `cors_allow_credentials=true` with `cors_allowed_origins=["*"]` is rejected at startup:
+
+```bash
+# Secure credentialed pattern: explicit origins, never "*"
+EVNT_SECURITY__CORS_ALLOWED_ORIGINS='["https://app.example.com"]'
+EVNT_SECURITY__CORS_ALLOW_CREDENTIALS=true
+```
+
+### Analytics-script proxy
+
+The optional proxy at `/proxy` fetches allowlisted third-party analytics scripts so you can serve them first-party. It is constrained to prevent SSRF:
+
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `EVNT_PROXY__DOMAINS` | `["google-analytics.com", "www.googletagmanager.com"]` | Hostname allowlist. |
+| `EVNT_PROXY__PATHS` | `["analytics.js", "gtm.js"]` | Path allowlist. |
+| `EVNT_PROXY__ALLOWED_PORTS` | `[80, 443]` | Outbound ports the proxy may reach on an allowlisted host. A target with no explicit port (the scheme default) is always permitted; any other port is rejected with `403`. |
+
+Redirects are **not** followed, so an allowlisted host cannot bounce the proxy to an internal target.
+
+### Secrets
+
+`EVNT_CLICKHOUSE__CONNECTION__PASSWORD` and `EVNT_INGEST__RABBITMQ__PASSWORD` are stored as Pydantic `SecretStr`: they are still configured the same way via environment variables, but their values are redacted from config dumps (`cli.py settings`) and logs.
+
+### ClickHouse and RabbitMQ
+
+| Setting | Default |
+| --- | --- |
+| `EVNT_CLICKHOUSE__CONNECTION__HOST` | `clickhouse` |
+| `EVNT_CLICKHOUSE__CONNECTION__PORT` | `8123` |
+| `EVNT_CLICKHOUSE__CONNECTION__USERNAME` | `default` |
+| `EVNT_CLICKHOUSE__CONNECTION__PASSWORD` | `password` (override in production) |
+| `EVNT_CLICKHOUSE__STARTUP_TIMEOUT_SECONDS` | `60` |
+| `EVNT_INGEST__MODE` | `direct` (alternative: `rabbitmq`) |
+| `EVNT_INGEST__RABBITMQ__HOST` | `rabbitmq` |
+| `EVNT_INGEST__RABBITMQ__PORT` | `5672` |
+| `EVNT_INGEST__RABBITMQ__QUEUE_NAME` | `evnt.ingest` |
+| `EVNT_INGEST__RABBITMQ__BATCH_SIZE` | `500` |
+
+On startup the app (and, in `rabbitmq` mode, the worker) retries the ClickHouse connection until `startup_timeout_seconds` elapses.
+
+### RabbitMQ worker
+
+In `rabbitmq` mode a separate worker drains the queue and batch-inserts into ClickHouse (`cli.py queue worker`). It shuts down cleanly on `SIGTERM` (final flush + close), publishes to the failed queue with publisher confirms to avoid silent loss, and backs off with capped exponential delay on downstream outages.
+
+The worker writes a liveness file that a dedicated healthcheck reads:
+
+```bash
+uv run python evnt/cli.py queue healthcheck
+```
+
+This is wired as the worker container `HEALTHCHECK` in [`compose.yml`](compose.yml); it reports unhealthy if the worker stops refreshing liveness. The staleness threshold stays above the worker's max backoff so a sustained backend outage is not misread as a dead worker.
 
 ## License & Attribution
 

--- a/evnt/cli.py
+++ b/evnt/cli.py
@@ -22,6 +22,8 @@ occurred during FastAPI lifespan startup.
 from __future__ import annotations
 
 import asyncio
+import signal
+import time
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -35,6 +37,8 @@ from clickhouse_connect import get_async_client
 from clickhouse_connect.driver.exceptions import ClickHouseError, DatabaseError
 from clickhouse_connect.driver.httputil import get_pool_manager
 from core.config import settings
+from core.constants import WORKER_LIVENESS_PATH, WORKER_LIVENESS_STALE_SECONDS
+from core.lifespan import retry_clickhouse_startup
 from ingest import RabbitMQBatchWorker
 from ingest.rabbitmq import connect_rabbitmq
 from plugins.logger import init_logging
@@ -77,7 +81,7 @@ async def _check_queue_worker_dependencies() -> dict[str, bool]:
     try:
         try:
             client = await get_async_client(
-                **ch_conf.connection.model_dump(),
+                **ch_conf.connection.as_client_kwargs(),
                 query_limit=0,
                 pool_mgr=pool_mgr,
             )
@@ -183,7 +187,7 @@ class DBCommands:
 
             try:
                 client = await get_async_client(
-                    **ch_conf.connection.model_dump(),
+                    **ch_conf.connection.as_client_kwargs(),
                     query_limit=0,
                     pool_mgr=pool_mgr,
                 )
@@ -317,10 +321,28 @@ class QueueCommands:
             queue_conf = settings.ingest.rabbitmq
 
             pool_mgr = get_pool_manager(maxsize=perf_conf.db_pool_size)
-            client = await get_async_client(
-                **ch_conf.connection.model_dump(),
-                query_limit=0,
-                pool_mgr=pool_mgr,
+
+            async def _create_ready_client():
+                client = await get_async_client(
+                    **ch_conf.connection.as_client_kwargs(),
+                    query_limit=0,
+                    pool_mgr=pool_mgr,
+                )
+                try:
+                    query = await client.query("SELECT 1")
+                    if query.first_row[0] != 1:
+                        raise RuntimeError(
+                            "ClickHouse readiness query returned unexpected result",
+                        )
+                    return client
+                except Exception:
+                    await client.close()
+                    raise
+
+            client = await retry_clickhouse_startup(
+                ch_conf,
+                "worker_create",
+                _create_ready_client,
             )
 
             connector = ClickHouseConnector(
@@ -330,8 +352,16 @@ class QueueCommands:
             )
             worker = await RabbitMQBatchWorker.create(connector, queue_conf)
 
+            # Install a SIGTERM handler so docker/k8s shutdown cancels the
+            # running task, letting the finally blocks flush and close cleanly.
+            loop = asyncio.get_running_loop()
+            current = asyncio.current_task()
+            loop.add_signal_handler(signal.SIGTERM, current.cancel)
+
             try:
                 await worker.run()
+            except asyncio.CancelledError:
+                self.logger.info("Worker received shutdown signal, flushing")
             finally:
                 await worker.close()
                 await client.close()
@@ -339,13 +369,65 @@ class QueueCommands:
         asyncio.run(_run())
         return "RabbitMQ worker stopped"
 
+    def _check_worker_liveness(self) -> bool:
+        """Check whether the worker liveness file is present and fresh.
+
+        The worker rewrites ``WORKER_LIVENESS_PATH`` with the wall-clock time
+        after each successful flush. A missing or stale file means the worker
+        loop is no longer making progress and should be considered dead.
+        """
+
+        try:
+            content = WORKER_LIVENESS_PATH.read_text()
+        except FileNotFoundError:
+            self.logger.error(
+                "Worker liveness file missing",
+                liveness_path=str(WORKER_LIVENESS_PATH),
+            )
+            return False
+        except OSError as exc:
+            self.logger.error(
+                "Failed to read worker liveness file",
+                liveness_path=str(WORKER_LIVENESS_PATH),
+                error=str(exc),
+            )
+            return False
+
+        try:
+            last_seen = float(content)
+        except ValueError:
+            self.logger.error(
+                "Worker liveness file contains invalid timestamp",
+                liveness_path=str(WORKER_LIVENESS_PATH),
+                content=content,
+            )
+            return False
+
+        age_seconds = time.time() - last_seen
+        if age_seconds > WORKER_LIVENESS_STALE_SECONDS:
+            self.logger.error(
+                "Worker liveness file is stale",
+                liveness_path=str(WORKER_LIVENESS_PATH),
+                age_seconds=age_seconds,
+                stale_seconds=WORKER_LIVENESS_STALE_SECONDS,
+            )
+            return False
+
+        return True
+
     def healthcheck(self) -> str:
-        """Check whether the RabbitMQ worker dependencies are healthy."""
+        """Check whether the RabbitMQ worker is alive and its deps are healthy."""
 
         init_logging(settings.logging.json_format, settings.logging.level)
+
+        is_alive = self._check_worker_liveness()
         status = asyncio.run(_check_queue_worker_dependencies())
-        if not all(status.values()):
-            self.logger.error("RabbitMQ worker health check failed", status=status)
+        if not is_alive or not all(status.values()):
+            self.logger.error(
+                "RabbitMQ worker health check failed",
+                liveness=is_alive,
+                status=status,
+            )
             raise SystemExit(1)
 
         return "ok"

--- a/evnt/cli.py
+++ b/evnt/cli.py
@@ -45,6 +45,11 @@ from plugins.logger import init_logging
 from routers.tracker.db.clickhouse import ClickHouseConnector, TableManager
 from starlette.status import HTTP_200_OK
 
+# ClickHouse ping query used for readiness checks
+_CH_READINESS_QUERY: str = "SELECT 1"
+# HTTP request timeout (seconds) for downloading tracker script bundles
+_SCRIPT_DOWNLOAD_TIMEOUT_SECONDS: int = 60
+
 
 def _build_clickhouse_insert_settings(*, require_wait: bool = False) -> dict[str, int]:
     """Build ClickHouse insert settings for direct and worker writes."""
@@ -85,7 +90,7 @@ async def _check_queue_worker_dependencies() -> dict[str, bool]:
                 query_limit=0,
                 pool_mgr=pool_mgr,
             )
-            query = await client.query("SELECT 1")
+            query = await client.query(_CH_READINESS_QUERY)
             status["clickhouse"] = query.first_row[0] == 1
         except Exception as exc:
             queue_logger.warning(
@@ -265,7 +270,9 @@ class ScriptsCommands:
         for filename in files:
             url = f"{base_url}/{filename}"
             self.logger.info("Downloading", url=url)
-            resp = httpx.get(url, timeout=60, follow_redirects=True)
+            resp = httpx.get(
+                url, timeout=_SCRIPT_DOWNLOAD_TIMEOUT_SECONDS, follow_redirects=True
+            )
             if resp.status_code != HTTP_200_OK:
                 raise RuntimeError(
                     f"Failed to download {filename}: HTTP {resp.status_code}",
@@ -290,10 +297,9 @@ class ScriptsCommands:
             loader_map = out_path / "loader.js.map"
             if loader_map.exists():
                 orig_text = loader_map.read_text(encoding="utf-8")
-                updated_text: str | None = None
                 data = orjson.loads(orig_text)
                 data["file"] = "loader.js"
-                updated_text = orjson.dumps(data).decode("utf-8")
+                updated_text: str = orjson.dumps(data).decode("utf-8")
                 loader_map.write_text(updated_text, encoding="utf-8")
                 self.logger.info("Updated loader.js.map file field to loader.js")
 
@@ -329,7 +335,7 @@ class QueueCommands:
                     pool_mgr=pool_mgr,
                 )
                 try:
-                    query = await client.query("SELECT 1")
+                    query = await client.query(_CH_READINESS_QUERY)
                     if query.first_row[0] != 1:
                         raise RuntimeError(
                             "ClickHouse readiness query returned unexpected result",

--- a/evnt/core/config.py
+++ b/evnt/core/config.py
@@ -9,7 +9,14 @@ import os
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
-from pydantic import AnyHttpUrl, BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    AnyHttpUrl,
+    BaseModel,
+    Field,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .constants import (
@@ -103,12 +110,12 @@ class LoggingConfig(BaseModel):
 class SecurityConfig(BaseModel):
     """Security-related configuration."""
 
-    disable_docs: bool = False
+    disable_docs: bool = True
     trusted_hosts: list[str] = ["*"]
     enable_https_redirect: bool = False
     trust_proxy_headers: bool = True
     cors_allowed_origins: list[str] = ["*"]
-    cors_allow_credentials: bool = True
+    cors_allow_credentials: bool = False
 
     @field_validator("cors_allowed_origins")
     @classmethod
@@ -148,6 +155,16 @@ class SecurityConfig(BaseModel):
 
         return normalized
 
+    @model_validator(mode="after")
+    def validate_cors_credentials(self) -> SecurityConfig:
+        """Reject combining credentialed CORS with wildcard origins."""
+
+        if self.cors_allowed_origins == ["*"] and self.cors_allow_credentials:
+            raise ValueError(
+                "cannot combine credentials with wildcard origins",
+            )
+        return self
+
 
 class ElasticAPMConfig(BaseModel):
     """Elastic APM configuration."""
@@ -182,6 +199,12 @@ class ProxyConfig(BaseModel):
 
     domains: list[str] = ["google-analytics.com", "www.googletagmanager.com"]
     paths: list[str] = ["analytics.js", "gtm.js"]
+    # Outbound ports the proxy is allowed to reach on an allowlisted host.
+    # The hostname allowlist alone does not constrain the port, so this keeps
+    # the proxy on standard web ports by default while letting operators opt
+    # into additional ports for hosts they explicitly trust. A target with no
+    # explicit port (the scheme default) is always permitted.
+    allowed_ports: list[int] = [80, 443]
 
 
 class PerformanceConfig(BaseModel):
@@ -205,8 +228,14 @@ class ClickHouseConnection(BaseModel):
     port: int = DEFAULT_CLICKHOUSE_PORT
     username: str = DEFAULT_CLICKHOUSE_USERNAME
     database: str = DEFAULT_CLICKHOUSE_DATABASE
-    password: str = "password"
+    password: SecretStr = SecretStr("password")
     connect_timeout: int = DEFAULT_DB_CONNECT_TIMEOUT
+
+    def as_client_kwargs(self) -> dict[str, Any]:
+        """Return connection kwargs with the password unwrapped for the client."""
+        data = self.model_dump()
+        data["password"] = self.password.get_secret_value()
+        return data
 
 
 class ClickHouseConfiguration(BaseModel):
@@ -281,7 +310,7 @@ class RabbitMQConfig(BaseModel):
     host: str = DEFAULT_RABBITMQ_HOST
     port: int = Field(default=DEFAULT_RABBITMQ_PORT, gt=0)
     username: str = "guest"
-    password: str = "guest"
+    password: SecretStr = SecretStr("guest")
     virtualhost: str = "/"
     queue_name: str = DEFAULT_RABBITMQ_QUEUE_NAME
     failed_queue_name: str | None = None

--- a/evnt/core/config.py
+++ b/evnt/core/config.py
@@ -6,6 +6,7 @@ Settings can be configured via environment variables with the EVNT_ prefix.
 """
 
 import os
+import re
 from typing import Any, Literal
 from urllib.parse import urlsplit
 
@@ -244,11 +245,30 @@ class ClickHouseConnection(BaseModel):
         return data
 
 
+_SQL_IDENTIFIER_RE = re.compile(r"[A-Za-z0-9_]+")
+
+
 class ClickHouseConfiguration(BaseModel):
     """ClickHouse table configuration."""
 
     database: str = DEFAULT_DATABASE_NAME
     cluster_name: str = ""
+
+    @field_validator("database", "cluster_name")
+    @classmethod
+    def validate_sql_identifier(cls, value: str) -> str:
+        """Reject database/cluster names that are not plain SQL identifiers.
+
+        These values are interpolated directly into DDL (``ON CLUSTER`` /
+        ``Distributed(...)`` / qualified table names), so constraining them to
+        ``[A-Za-z0-9_]`` closes a config-injection surface. ``cluster_name`` may
+        be empty (meaning "no cluster").
+        """
+        if value and not _SQL_IDENTIFIER_RE.fullmatch(value):
+            raise ValueError(
+                f"must be a plain SQL identifier ([A-Za-z0-9_]), got {value!r}",
+            )
+        return value
 
     # Can be overridden via environment variables such as:
     # EVNT_CLICKHOUSE__CONFIGURATION__TABLES__EVNT__LOCAL__ENGINE=

--- a/evnt/core/config.py
+++ b/evnt/core/config.py
@@ -90,6 +90,11 @@ class Snowplow(BaseModel):
         return header_name
 
 
+_VALID_LOG_LEVELS: frozenset[str] = frozenset(
+    {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+)
+
+
 class LoggingConfig(BaseModel):
     """Logging configuration."""
 
@@ -100,10 +105,11 @@ class LoggingConfig(BaseModel):
     @classmethod
     def validate_level(cls, v: str) -> str:
         """Ensure log level is uppercase and valid."""
-        valid_levels = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
         upper_v = v.upper()
-        if upper_v not in valid_levels:
-            raise ValueError(f"Invalid log level: {v}. Must be one of {valid_levels}")
+        if upper_v not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"Invalid log level: {v}. Must be one of {_VALID_LOG_LEVELS}"
+            )
         return upper_v
 
 

--- a/evnt/core/constants.py
+++ b/evnt/core/constants.py
@@ -78,6 +78,11 @@ DEFAULT_RABBITMQ_STARTUP_RETRY_INTERVAL_MS: Final[int] = 1000
 # liveness writes) cannot be misread as a dead worker.
 WORKER_LIVENESS_PATH: Final[Path] = Path(tempfile.gettempdir()) / "evnt-worker.alive"
 WORKER_LIVENESS_STALE_SECONDS: Final[int] = 120
+# How often the worker proactively refreshes its liveness file, independent of
+# message flow / batch timeout / backoff. Kept well below the stale threshold so
+# an idle worker (even with a large EVNT_INGEST__RABBITMQ__BATCH_TIMEOUT_MS) is
+# never mistaken for dead between writes.
+WORKER_HEARTBEAT_SECONDS: Final[int] = WORKER_LIVENESS_STALE_SECONDS // 3
 
 # Async insert settings for ClickHouse
 CLICKHOUSE_ASYNC_SETTINGS: Final[dict[str, int]] = {

--- a/evnt/core/constants.py
+++ b/evnt/core/constants.py
@@ -6,6 +6,8 @@ to improve maintainability and reduce magic strings/numbers.
 """
 
 import base64
+import tempfile
+from pathlib import Path
 from typing import Final
 
 # Application metadata
@@ -35,7 +37,6 @@ DEFAULT_TABLE_GROUP: Final[str] = "evnt"
 SECURITY_HEADERS: Final[dict[str, str]] = {
     "X-Content-Type-Options": "nosniff",
     "X-Frame-Options": "DENY",
-    "X-XSS-Protection": "1; mode=block",
     "Referrer-Policy": "strict-origin-when-cross-origin",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
 }
@@ -67,6 +68,16 @@ DEFAULT_RABBITMQ_RETRY_DELAY_MS: Final[int] = 1000
 DEFAULT_RABBITMQ_CONNECT_TIMEOUT_SECONDS: Final[int] = 5
 DEFAULT_RABBITMQ_STARTUP_TIMEOUT_SECONDS: Final[int] = 60
 DEFAULT_RABBITMQ_STARTUP_RETRY_INTERVAL_MS: Final[int] = 1000
+
+# Worker liveness contract
+# The worker writes the wall-clock time of its last successful flush to this
+# file; the healthcheck considers the worker dead if the file is missing or the
+# recorded timestamp is older than the staleness threshold. This threshold must
+# stay strictly greater than the worker's MAX_BACKOFF_SECONDS so a sustained
+# backend outage (which makes the worker sleep up to one full backoff between
+# liveness writes) cannot be misread as a dead worker.
+WORKER_LIVENESS_PATH: Final[Path] = Path(tempfile.gettempdir()) / "evnt-worker.alive"
+WORKER_LIVENESS_STALE_SECONDS: Final[int] = 120
 
 # Async insert settings for ClickHouse
 CLICKHOUSE_ASYNC_SETTINGS: Final[dict[str, int]] = {

--- a/evnt/core/healthcheck.py
+++ b/evnt/core/healthcheck.py
@@ -18,6 +18,9 @@ from .protocols import HealthChecker
 
 logger = structlog.get_logger(__name__)
 
+# SQL used to verify ClickHouse connectivity during health checks.
+_CLICKHOUSE_HEALTH_QUERY: str = "SELECT 1"
+
 
 class HealthProbeResponse(BaseModel):
     """JSON shape returned by the health probe endpoint."""
@@ -83,7 +86,7 @@ class ClickHouseHealthChecker:
 
         healthy = True
         try:
-            query = await self.client.query("SELECT 1")
+            query = await self.client.query(_CLICKHOUSE_HEALTH_QUERY)
             healthy = query.first_row[0] == 1
         except Exception as exc:
             logger.warning("ClickHouse health check failed", error=str(exc))

--- a/evnt/core/healthcheck.py
+++ b/evnt/core/healthcheck.py
@@ -11,11 +11,21 @@ import structlog
 from fastapi import Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from starlette.status import HTTP_200_OK, HTTP_502_BAD_GATEWAY
 
 from .protocols import HealthChecker
 
 logger = structlog.get_logger(__name__)
+
+
+class HealthProbeResponse(BaseModel):
+    """JSON shape returned by the health probe endpoint."""
+
+    status: dict[str, bool]
+    healthy: bool
+    ingest_mode: str
+    table: str | None = None
 
 
 class CachedHealthChecker:
@@ -82,11 +92,16 @@ class ClickHouseHealthChecker:
         return {"clickhouse": healthy}
 
 
-async def probe(request: Request) -> JSONResponse:
+async def probe(request: Request) -> HealthProbeResponse:
     """
     Health check probe endpoint.
 
     Checks the active ingest backend and returns status information.
+
+    The declared return type lets FastAPI document the 200 body in OpenAPI.
+    A ``JSONResponse`` is still returned directly so the HTTP status code can
+    reflect backend health; FastAPI skips re-serialization for ``Response``
+    subclasses.
 
     Args:
         request: The incoming request

--- a/evnt/core/lifespan.py
+++ b/evnt/core/lifespan.py
@@ -24,6 +24,14 @@ from .protocols import HealthChecker
 
 logger = structlog.get_logger(__name__)
 
+# Seconds a keepalive connection may remain idle before being closed.
+# 30 s is a pragmatic default that sits well below most reverse-proxy idle
+# timeouts (typically 60–120 s) while avoiding aggressive churn.
+_KEEPALIVE_EXPIRY_SECONDS: float = 30.0
+
+# SQL used to verify ClickHouse connectivity at startup.
+_CLICKHOUSE_READINESS_QUERY: str = "SELECT 1"
+
 PERFORMANCE_CONFIG = settings.performance
 CLICKHOUSE_CONFIG = settings.clickhouse
 INGEST_CONFIG = settings.ingest
@@ -67,7 +75,7 @@ async def _create_ready_clickhouse_client():
 
     client = await _create_clickhouse_client()
     try:
-        query = await client.query("SELECT 1")
+        query = await client.query(_CLICKHOUSE_READINESS_QUERY)
         if query.first_row[0] != 1:
             raise RuntimeError("ClickHouse readiness query returned unexpected result")
         return client
@@ -177,7 +185,7 @@ async def _configure_proxy_http_client(
     limits = httpx.Limits(
         max_connections=PERFORMANCE_CONFIG.max_concurrent_connections,
         max_keepalive_connections=PERFORMANCE_CONFIG.max_concurrent_connections,
-        keepalive_expiry=30.0,
+        keepalive_expiry=_KEEPALIVE_EXPIRY_SECONDS,
     )
     application.state.proxy_http_client = httpx.AsyncClient(
         # The allowlist (proxy_allowed_hosts) is only validated against the

--- a/evnt/core/lifespan.py
+++ b/evnt/core/lifespan.py
@@ -56,7 +56,7 @@ async def _create_clickhouse_client():
 
     pool_mgr = get_pool_manager(maxsize=PERFORMANCE_CONFIG.db_pool_size)
     return await get_async_client(
-        **CLICKHOUSE_CONFIG.connection.model_dump(),
+        **CLICKHOUSE_CONFIG.connection.as_client_kwargs(),
         query_limit=0,
         pool_mgr=pool_mgr,
     )
@@ -177,15 +177,21 @@ async def _configure_proxy_http_client(
     limits = httpx.Limits(
         max_connections=PERFORMANCE_CONFIG.max_concurrent_connections,
         max_keepalive_connections=PERFORMANCE_CONFIG.max_concurrent_connections,
+        keepalive_expiry=30.0,
     )
     application.state.proxy_http_client = httpx.AsyncClient(
-        follow_redirects=True,
+        # The allowlist (proxy_allowed_hosts) is only validated against the
+        # initial request URL. Auto-following redirects would let a permitted
+        # host bounce the request to an arbitrary internal target (SSRF), so
+        # redirects must not be followed automatically.
+        follow_redirects=False,
         timeout=DEFAULT_PROXY_TIMEOUT,
         limits=limits,
     )
     application.state.proxy_allowed_hosts = frozenset(
         domain.rstrip(".").lower() for domain in config.domains
     )
+    application.state.proxy_allowed_ports = frozenset(config.allowed_ports)
     application.state._closeables.append(application.state.proxy_http_client)
 
 
@@ -268,7 +274,9 @@ async def lifespan(application: FastAPI) -> AsyncGenerator[None]:
             await _configure_direct_ingest(application)
 
         await _configure_proxy_http_client(application)
-        warm_known_iglu_schemas()
+        # warm_known_iglu_schemas performs synchronous file I/O; run it in a
+        # thread so it does not block the event loop during async startup.
+        await asyncio.to_thread(warm_known_iglu_schemas)
         logger.info("Ingest backend initialized")
 
     except Exception as e:

--- a/evnt/ingest/rabbitmq.py
+++ b/evnt/ingest/rabbitmq.py
@@ -21,7 +21,7 @@ from aio_pika.abc import (
 from aio_pika.exceptions import AuthenticationError, ProbableAuthenticationError
 from clickhouse_connect.driver.exceptions import DataError
 from core.config import RabbitMQConfig
-from core.constants import WORKER_LIVENESS_PATH
+from core.constants import WORKER_HEARTBEAT_SECONDS, WORKER_LIVENESS_PATH
 from core.protocols import RowSink
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
@@ -316,6 +316,7 @@ class RabbitMQBatchWorker:
 
         iterator = self.queue.iterator()
         next_message_task: asyncio.Task[AbstractIncomingMessage] | None = None
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop())
         try:
             async with iterator:
                 while True:
@@ -343,6 +344,9 @@ class RabbitMQBatchWorker:
                     await self.add_message(message)
                     self._mark_alive()
         finally:
+            heartbeat_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await heartbeat_task
             if next_message_task is not None and not next_message_task.done():
                 next_message_task.cancel()
                 with suppress(asyncio.CancelledError):
@@ -392,6 +396,19 @@ class RabbitMQBatchWorker:
                 error=str(exc),
                 path=str(WORKER_LIVENESS_PATH),
             )
+
+    async def _heartbeat_loop(self) -> None:
+        """Refresh the liveness file on a fixed cadence.
+
+        Runs as a background task for the worker's lifetime so liveness is
+        decoupled from message flow, the batch-flush timeout, and backoff. This
+        keeps an idle worker (or one configured with a large batch timeout) from
+        being mistaken for dead by ``queue healthcheck``.
+        """
+
+        while True:
+            self._mark_alive()
+            await asyncio.sleep(WORKER_HEARTBEAT_SECONDS)
 
     async def add_message(self, message: AbstractIncomingMessage) -> None:
         """Decode and buffer a message."""

--- a/evnt/ingest/rabbitmq.py
+++ b/evnt/ingest/rabbitmq.py
@@ -28,6 +28,9 @@ from pydantic import BaseModel, Field
 
 logger = structlog.get_logger(__name__)
 
+# Milliseconds per second — used when converting ms config values to seconds.
+_MS_PER_SECOND = 1000
+
 # Assigned to a name so ruff-format (PEP 758 preview) does not rewrite the
 # `except (A, B):` literal into the bare `except A, B:` form.
 _AUTH_ERRORS = (AuthenticationError, ProbableAuthenticationError)
@@ -114,7 +117,7 @@ async def retry_rabbitmq_startup[T](
                 raise
 
             retry_in_seconds = min(
-                config.startup_retry_interval_ms / 1000,
+                config.startup_retry_interval_ms / _MS_PER_SECOND,
                 remaining_seconds,
             )
             logger.warning(
@@ -269,8 +272,8 @@ class RabbitMQBatchWorker:
         self.sink = sink
         self.config = config
         self.failed_queue_name = config.resolved_failed_queue_name
-        self.flush_interval = config.batch_timeout_ms / 1000
-        self.retry_delay = config.retry_delay_ms / 1000
+        self.flush_interval = config.batch_timeout_ms / _MS_PER_SECOND
+        self.retry_delay = config.retry_delay_ms / _MS_PER_SECOND
         self.pending_batches: dict[str, list[PendingMessage]] = defaultdict(list)
         self.pending_row_counts: dict[str, int] = defaultdict(int)
         # Per-table-group consecutive insert-failure counts, used to drive a

--- a/evnt/ingest/rabbitmq.py
+++ b/evnt/ingest/rabbitmq.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
@@ -20,6 +21,7 @@ from aio_pika.abc import (
 from aio_pika.exceptions import AuthenticationError, ProbableAuthenticationError
 from clickhouse_connect.driver.exceptions import DataError
 from core.config import RabbitMQConfig
+from core.constants import WORKER_LIVENESS_PATH
 from core.protocols import RowSink
 from fastapi.encoders import jsonable_encoder
 from pydantic import BaseModel, Field
@@ -74,7 +76,7 @@ async def connect_rabbitmq(config: RabbitMQConfig) -> AbstractRobustConnection:
         host=config.host,
         port=config.port,
         login=config.username,
-        password=config.password,
+        password=config.password.get_secret_value(),
         virtualhost=config.virtualhost,
         timeout=config.connect_timeout_seconds,
     )
@@ -181,9 +183,10 @@ class RabbitMQPublisher:
             logger.debug("No rows to enqueue", table_group=table_group)
             return
 
+        encoded_rows = await asyncio.to_thread(jsonable_encoder, rows)
         payload = QueuedInsertPayload(
             table_group=table_group,
-            rows=jsonable_encoder(rows),
+            rows=encoded_rows,
         )
         message = Message(
             body=payload.model_dump_json().encode("utf-8"),
@@ -248,6 +251,10 @@ class RabbitMQHealthChecker:
 class RabbitMQBatchWorker:
     """Consumes RabbitMQ messages and writes batched rows to ClickHouse."""
 
+    # Cap exponential backoff so the consumer never stalls indefinitely
+    # between iterations when ClickHouse is persistently unavailable.
+    MAX_BACKOFF_SECONDS = 60.0
+
     def __init__(
         self,
         connection: AbstractRobustConnection,
@@ -266,6 +273,10 @@ class RabbitMQBatchWorker:
         self.retry_delay = config.retry_delay_ms / 1000
         self.pending_batches: dict[str, list[PendingMessage]] = defaultdict(list)
         self.pending_row_counts: dict[str, int] = defaultdict(int)
+        # Per-table-group consecutive insert-failure counts, used to drive a
+        # capped exponential backoff applied in ``run`` BETWEEN iterations
+        # (never while holding/awaiting an in-flight message).
+        self.failure_counts: dict[str, int] = defaultdict(int)
 
     @classmethod
     async def create(
@@ -278,7 +289,7 @@ class RabbitMQBatchWorker:
         async def _create() -> RabbitMQBatchWorker:
             connection = await connect_rabbitmq(config)
             try:
-                channel = await connection.channel()
+                channel = await connection.channel(publisher_confirms=True)
                 await channel.set_qos(prefetch_count=config.prefetch_count)
                 await _declare_ingest_queues(channel, config)
                 queue = await channel.declare_queue(config.queue_name, durable=True)
@@ -305,6 +316,12 @@ class RabbitMQBatchWorker:
         try:
             async with iterator:
                 while True:
+                    # Apply any pending capped exponential backoff BEFORE
+                    # fetching the next message so failing inserts do not stall
+                    # the consumer mid-flush (which would hold prefetch and
+                    # block ack/nack of already-received messages).
+                    await self._apply_backoff()
+
                     if next_message_task is None:
                         next_message_task = asyncio.create_task(iterator.__anext__())
                     try:
@@ -314,18 +331,64 @@ class RabbitMQBatchWorker:
                         )
                     except TimeoutError:
                         await self.flush_all()
+                        self._mark_alive()
                         continue
                     except StopAsyncIteration:
                         break
 
                     next_message_task = None
                     await self.add_message(message)
+                    self._mark_alive()
         finally:
             if next_message_task is not None and not next_message_task.done():
                 next_message_task.cancel()
                 with suppress(asyncio.CancelledError):
                     await next_message_task
             await self.flush_all()
+
+    def _backoff_seconds(self) -> float:
+        """Return the current backoff delay derived from failure counts.
+
+        Uses the worst (highest) consecutive-failure count across all table
+        groups so a single persistently failing destination throttles the
+        loop. Returns ``0`` when there have been no recent failures.
+        """
+
+        max_failures = max(self.failure_counts.values(), default=0)
+        if max_failures <= 0:
+            return 0.0
+        # base * 2**(n-1), capped, so the first failure waits ``retry_delay``.
+        delay = self.retry_delay * (2 ** (max_failures - 1))
+        return min(delay, self.MAX_BACKOFF_SECONDS)
+
+    async def _apply_backoff(self) -> None:
+        """Sleep for the capped exponential backoff between run iterations."""
+
+        delay = self._backoff_seconds()
+        if delay <= 0:
+            return
+        logger.warning(
+            "Backing off before next RabbitMQ batch iteration",
+            backoff_seconds=delay,
+            failure_counts=dict(self.failure_counts),
+        )
+        await asyncio.sleep(delay)
+        # Refresh liveness right after a long backoff so a sustained backend
+        # outage cannot make the healthcheck see a stale file and trigger a
+        # spurious restart while the worker is healthy and retrying.
+        self._mark_alive()
+
+    def _mark_alive(self) -> None:
+        """Record worker liveness; never crash the worker on I/O errors."""
+
+        try:
+            WORKER_LIVENESS_PATH.write_text(str(time.time()))
+        except OSError as exc:
+            logger.warning(
+                "Failed to write worker liveness file",
+                error=str(exc),
+                path=str(WORKER_LIVENESS_PATH),
+            )
 
     async def add_message(self, message: AbstractIncomingMessage) -> None:
         """Decode and buffer a message."""
@@ -396,9 +459,19 @@ class RabbitMQBatchWorker:
         self,
         table_group: str,
         pending: list[PendingMessage],
-    ) -> None:
+    ) -> bool:
+        """Flush a set of pending messages.
+
+        Returns ``True`` when the messages made progress off the main queue
+        (inserted or routed to the failed queue) and ``False`` when a transient
+        failure caused them to be nack'd/requeued. Backoff (applied between run
+        iterations) is driven by this result so the consumer is never stalled
+        mid-flush while holding prefetch or before ack/nack of in-flight
+        messages.
+        """
+
         if not pending:
-            return
+            return True
 
         rows = [row for item in pending for row in item.payload.rows]
         rows_count = len(rows)
@@ -428,10 +501,9 @@ class RabbitMQBatchWorker:
                         failed_queue_name=self.failed_queue_name,
                     )
                     await pending[0].message.nack(requeue=True)
-                    await asyncio.sleep(self.retry_delay)
-                    return
+                    return False
                 await pending[0].message.ack()
-                return
+                return True
 
             midpoint = max(1, len(pending) // 2)
             logger.warning(
@@ -441,9 +513,9 @@ class RabbitMQBatchWorker:
                 rows_count=rows_count,
                 messages_count=len(pending),
             )
-            await self._flush_pending_messages(table_group, pending[:midpoint])
-            await self._flush_pending_messages(table_group, pending[midpoint:])
-            return
+            first = await self._flush_pending_messages(table_group, pending[:midpoint])
+            second = await self._flush_pending_messages(table_group, pending[midpoint:])
+            return first and second
         except Exception as exc:
             logger.error(
                 "Batch insert failed, requeueing messages",
@@ -454,8 +526,7 @@ class RabbitMQBatchWorker:
             )
             for item in pending:
                 await item.message.nack(requeue=True)
-            await asyncio.sleep(self.retry_delay)
-            return
+            return False
 
         for item in pending:
             await item.message.ack()
@@ -466,15 +537,25 @@ class RabbitMQBatchWorker:
             rows_count=rows_count,
             messages_count=len(pending),
         )
+        return True
 
     async def flush_table_group(self, table_group: str) -> None:
-        """Flush a single table group and ack or requeue source messages."""
+        """Flush a single table group and ack or requeue source messages.
+
+        Updates the per-table-group consecutive-failure count that drives the
+        capped exponential backoff applied between run-loop iterations: the
+        count is reset on success and incremented on a transient failure.
+        """
 
         pending = self.pending_batches.pop(table_group, [])
         self.pending_row_counts.pop(table_group, 0)
         if not pending:
             return
-        await self._flush_pending_messages(table_group, pending)
+        succeeded = await self._flush_pending_messages(table_group, pending)
+        if succeeded:
+            self.failure_counts.pop(table_group, None)
+        else:
+            self.failure_counts[table_group] += 1
 
     async def close(self) -> None:
         """Close RabbitMQ resources."""

--- a/evnt/main.py
+++ b/evnt/main.py
@@ -55,7 +55,9 @@ def _get_base_middleware() -> list[Middleware]:
             if allow_all_origins
             else settings.security.cors_allowed_origins,
             allow_origin_regex=".*" if allow_all_origins else None,
-            allow_credentials=settings.security.cors_allow_credentials,
+            allow_credentials=(
+                settings.security.cors_allow_credentials and not allow_all_origins
+            ),
             allow_methods=["*"],
             allow_headers=["*"],
             expose_headers=["*"],
@@ -102,7 +104,12 @@ def _configure_routers(app: FastAPI) -> None:
     """Configure and include all routers."""
     app.include_router(app_router)
     app.include_router(proxy_router)
-    app.mount("/static", StaticFiles(directory="static"), name="static")
+    # check_dir=False so the app boots even when the static assets have not been
+    # downloaded yet (they are fetched at container build time, and the dir is
+    # gitignored). Requests to /static/* simply 404 until the dir is populated.
+    app.mount(
+        "/static", StaticFiles(directory="static", check_dir=False), name="static"
+    )
 
     # Mount demo static assets if enabled (there are no dynamic demo routes).
     # The Vue SPA is built into routers/demo/web/dist by Vite (`npm run build`).
@@ -120,14 +127,15 @@ def _configure_integrations(app: FastAPI) -> None:
     if settings.elastic_apm.enabled:
         try:
             from elasticapm.contrib.starlette import ElasticAPM
-            from plugins.elastic_apm import elastic_apm_client
+            from plugins.elastic_apm import create_elastic_apm_client
         except ImportError as exc:
             raise RuntimeError(
                 "Elastic APM is enabled but `elastic-apm` is not installed. "
                 "Install the optional extra: `uv sync --extra apm`.",
             ) from exc
 
-        app.add_middleware(ElasticAPM, client=elastic_apm_client)
+        client = create_elastic_apm_client()
+        app.add_middleware(ElasticAPM, client=client)
 
     # Add Prometheus middleware if enabled
     if settings.prometheus.enabled:
@@ -174,6 +182,7 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
         docs_url=None if settings.security.disable_docs else "/docs",
         redoc_url=None if settings.security.disable_docs else "/redoc",
+        openapi_url=None if settings.security.disable_docs else "/openapi.json",
         middleware=_get_base_middleware(),
     )
 

--- a/evnt/middleware/base.py
+++ b/evnt/middleware/base.py
@@ -63,8 +63,10 @@ class BaseMiddleware(BaseHTTPMiddleware):
                 if isinstance(modified_request, Response):
                     return modified_request
 
-            # Call next handler
-            response = await call_next(request)
+            # Call next handler, using the modified request when one was returned
+            response = await call_next(
+                modified_request if isinstance(modified_request, Request) else request
+            )
 
             # Post-processing hook
             response = await self.process_response(request, response)

--- a/evnt/middleware/security.py
+++ b/evnt/middleware/security.py
@@ -10,8 +10,6 @@ from fastapi import Request, Response
 
 from .base import BaseMiddleware
 
-SECURITY_CONFIG = settings.security
-
 
 class SecurityHeadersMiddleware(BaseMiddleware):
     """
@@ -28,6 +26,8 @@ class SecurityHeadersMiddleware(BaseMiddleware):
 
     def __init__(self, app):
         super().__init__(app)
+        # Read security settings at init time (not import time) for testability
+        self._security_config = settings.security
         # Build headers dict once at initialization
         self._headers = self._build_headers()
 
@@ -36,7 +36,7 @@ class SecurityHeadersMiddleware(BaseMiddleware):
         headers = dict(SECURITY_HEADERS)
 
         # Add HSTS header if HTTPS redirect is enabled
-        if SECURITY_CONFIG.enable_https_redirect:
+        if self._security_config.enable_https_redirect:
             headers["Strict-Transport-Security"] = HSTS_HEADER
 
         return headers

--- a/evnt/plugins/elastic_apm.py
+++ b/evnt/plugins/elastic_apm.py
@@ -1,11 +1,22 @@
+"""Elastic APM client integration.
+
+The APM client is built lazily via :func:`create_elastic_apm_client` rather than
+at module import time, so importing this module has no side effects (no config
+reading or network/transport setup) until a caller explicitly opts in.
+"""
+
 from core.config import settings
 from elasticapm.contrib.starlette import make_apm_client
 
-ELASTIC_APM_CONFIG = settings.elastic_apm
 
-elastic_config = ELASTIC_APM_CONFIG.model_dump()
-elastic_enabled = elastic_config.pop("enabled")
-elastic_config["SERVICE_NAME"] = settings.common.service_name
+def create_elastic_apm_client():
+    """Build and return an Elastic APM client from the current settings.
 
-if elastic_enabled:
-    elastic_apm_client = make_apm_client(elastic_config)
+    The Elastic APM configuration is read inside the function so the client is
+    created lazily on call, never at import time.
+    """
+    elastic_config = settings.elastic_apm.model_dump()
+    elastic_config.pop("enabled")
+    elastic_config["SERVICE_NAME"] = settings.common.service_name
+
+    return make_apm_client(elastic_config)

--- a/evnt/routers/proxy/__init__.py
+++ b/evnt/routers/proxy/__init__.py
@@ -27,16 +27,13 @@ PROXY_CONFIG = settings.proxy
 PROXY_ENDPOINT = settings.common.snowplow.endpoints.proxy_endpoint
 HOSTNAME = settings.common.hostname
 ALLOWED_PROXY_SCHEMES: Final[frozenset[str]] = frozenset({"http", "https"})
+# Fallback used only if the lifespan did not populate the port allowlist.
+DEFAULT_ALLOWED_PROXY_PORTS: Final[frozenset[int]] = frozenset({80, 443})
 
 
 def _normalize_hostname(hostname: str) -> str:
     """Normalize hostnames for allowlist comparison."""
     return hostname.rstrip(".").lower()
-
-
-ALLOWED_PROXY_HOSTS: Final[frozenset[str]] = frozenset(
-    _normalize_hostname(domain) for domain in PROXY_CONFIG.domains
-)
 
 
 router = APIRouter(tags=["proxy"], prefix=PROXY_ENDPOINT)
@@ -73,9 +70,21 @@ def _should_encode_path(path: str) -> bool:
 
 
 def _get_proxy_allowed_hosts(request: Request) -> frozenset[str]:
-    """Return the configured proxy host allowlist."""
+    """Return the lifespan-owned proxy host allowlist."""
 
-    return getattr(request.app.state, "proxy_allowed_hosts", ALLOWED_PROXY_HOSTS)
+    allowed_hosts = getattr(request.app.state, "proxy_allowed_hosts", None)
+    if allowed_hosts is None:
+        raise HTTPException(status_code=500, detail="Proxy is not ready")
+    return allowed_hosts
+
+
+def _get_proxy_allowed_ports(request: Request) -> frozenset[int]:
+    """Return the lifespan-owned set of permitted outbound ports."""
+
+    allowed_ports = getattr(request.app.state, "proxy_allowed_ports", None)
+    if allowed_ports is None:
+        return DEFAULT_ALLOWED_PROXY_PORTS
+    return allowed_ports
 
 
 def _get_proxy_http_client(request: Request) -> httpx.AsyncClient:
@@ -87,7 +96,7 @@ def _get_proxy_http_client(request: Request) -> httpx.AsyncClient:
     return client
 
 
-@router.post("/hash")
+@router.post("/hash", response_model=AnyHttpUrl, status_code=200)
 async def proxy_hash(data: models.HashModel) -> AnyHttpUrl:
     """
     Generate a proxied URL for an external resource.
@@ -132,7 +141,15 @@ async def proxy_hash(data: models.HashModel) -> AnyHttpUrl:
     return result
 
 
-@router.get("/route/{schema}/{host}/{path}")
+@router.get(
+    "/route/{schema}/{host}/{path}",
+    responses={
+        400: {"description": "Unsupported proxy scheme or invalid proxy target"},
+        403: {"description": "Proxy target host or port not allowed"},
+        502: {"description": "Proxy request to the upstream target failed"},
+        504: {"description": "Proxy request to the upstream target timed out"},
+    },
+)
 async def proxy(
     request: Request,
     schema: str,
@@ -168,6 +185,16 @@ async def proxy(
     # (cloud metadata, internal services, localhost, ...).
     if _normalize_hostname(target_url.host) not in _get_proxy_allowed_hosts(request):
         raise HTTPException(status_code=403, detail="Proxy target not allowed")
+
+    # The host allowlist check above compares only the hostname, so an attacker
+    # could append an arbitrary port (e.g. "google-analytics.com:9200") to reach
+    # internal services. Restrict the outbound port to the configured allowlist
+    # (standard web ports by default); a target with no explicit port uses the
+    # scheme default and is always permitted.
+    if target_url.port is not None and target_url.port not in _get_proxy_allowed_ports(
+        request
+    ):
+        raise HTTPException(status_code=403, detail="Proxy target port not allowed")
 
     try:
         client = _get_proxy_http_client(request)

--- a/evnt/routers/proxy/models.py
+++ b/evnt/routers/proxy/models.py
@@ -1,6 +1,5 @@
-from fastapi import Query
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, Field
 
 
 class HashModel(BaseModel):
-    url: AnyUrl = Query(..., title="URL to hash")
+    url: AnyUrl = Field(..., title="URL to hash")

--- a/evnt/routers/proxy/models.py
+++ b/evnt/routers/proxy/models.py
@@ -2,4 +2,6 @@ from pydantic import AnyUrl, BaseModel, Field
 
 
 class HashModel(BaseModel):
+    """Request body for the proxy hash endpoint."""
+
     url: AnyUrl = Field(..., title="URL to hash")

--- a/evnt/routers/tracker/__init__.py
+++ b/evnt/routers/tracker/__init__.py
@@ -6,8 +6,10 @@ and services using the Snowplow tracking protocol.
 """
 
 from core.config import settings
+from core.constants import CONTENT_TYPE_GIF
 from fastapi.responses import Response
 from fastapi.routing import APIRouter
+from starlette.status import HTTP_204_NO_CONTENT
 
 from .routes import tracker_cors, tracker_get, tracker_post  # sendgrid_event
 
@@ -17,20 +19,39 @@ endpoints = settings.common.snowplow.endpoints
 
 router = APIRouter(tags=["tracker"])
 
-# Register the CORS options handlers
-router.options(endpoints.post_endpoint, include_in_schema=False)(tracker_cors)
-router.options(endpoints.get_endpoint, include_in_schema=False)(tracker_cors)
+# Register the CORS options handlers.
+# Preflight responses carry no body, so return an explicit 204 No Content.
+router.options(
+    endpoints.post_endpoint,
+    include_in_schema=False,
+    status_code=HTTP_204_NO_CONTENT,
+)(tracker_cors)
+router.options(
+    endpoints.get_endpoint,
+    include_in_schema=False,
+    status_code=HTTP_204_NO_CONTENT,
+)(tracker_cors)
 
-# Register the main Snowplow endpoints
+# Register the main Snowplow endpoints.
+# The handler returns 204 No Content, so document that status in OpenAPI.
 router.post(
     endpoints.post_endpoint,
     summary="Snowplow JS Tracker endpoint",
+    status_code=HTTP_204_NO_CONTENT,
 )(tracker_post)
 
+# The GET handler returns a 1x1 GIF tracking pixel; document the binary
+# image/gif response so the schema reflects the actual media type.
 router.get(
     endpoints.get_endpoint,
     summary="Snowplow JS Tracker GET endpoint",
     response_class=Response,
+    responses={
+        200: {
+            "content": {CONTENT_TYPE_GIF: {}},
+            "description": "1x1 transparent GIF tracking pixel",
+        },
+    },
 )(tracker_get)
 
 # Register the SendGrid webhook endpoint

--- a/evnt/routers/tracker/db/clickhouse/connector.py
+++ b/evnt/routers/tracker/db/clickhouse/connector.py
@@ -69,7 +69,7 @@ class ClickHouseConnector:
         Returns:
             The ON CLUSTER clause or empty string
         """
-        if cluster_name is None or not cluster_name:
+        if not cluster_name:
             return ""
         return f"ON CLUSTER {cluster_name}"
 

--- a/evnt/routers/tracker/db/clickhouse/connector.py
+++ b/evnt/routers/tracker/db/clickhouse/connector.py
@@ -6,6 +6,7 @@ This module provides a connection to ClickHouse.
 
 from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 import structlog
 from clickhouse_connect.driver.asyncclient import AsyncClient
@@ -15,6 +16,9 @@ from core.tracing import async_capture_span
 from routers.tracker.db.clickhouse.schemas.snowplow import ColumnDef, TupleColumnDef
 
 logger = structlog.get_logger(__name__)
+
+# Explicit all-zero UUID written for non-Nullable UUID columns that are missing.
+_ZERO_UUID = UUID(int=0)
 
 
 @dataclass(frozen=True, slots=True)
@@ -186,12 +190,25 @@ class ClickHouseConnector:
 
     @staticmethod
     def _sanitize_clickhouse_value(type_name: str, value: Any) -> Any:
-        """Coerce `None` into a safe default for non-nullable string columns."""
+        """Coerce ``None`` into an explicit, type-correct default for non-Nullable columns.
+
+        Several non-Nullable columns are optional in the payload models (e.g.
+        ``device_id`` / ``session_id`` are ``UUID | None``). Rather than relying
+        on the driver to silently zero-fill, map ``None`` to the column type's
+        zero value explicitly.
+
+        NOTE: a missing ``device_id`` becomes the all-zero UUID, which is also
+        the ``SAMPLE BY``/``ORDER BY`` key (``cityHash64(device_id)``); all
+        anonymous events therefore share one sample-key value. Changing that is
+        a sampling-design decision, out of scope for value sanitization.
+        """
 
         if value is not None:
             return value
         if type_name == "String" or type_name.startswith("LowCardinality(String"):
             return ""
+        if type_name == "UUID":
+            return _ZERO_UUID
         return value
 
     async def insert_batch(

--- a/evnt/routers/tracker/db/clickhouse/schemas/snowplow.py
+++ b/evnt/routers/tracker/db/clickhouse/schemas/snowplow.py
@@ -36,8 +36,12 @@ class ColumnDef(NamedTuple):
         type_name = self.type_name
 
         parts = [quote_identifier(self.name), type_name]
-        if self.default_type:
-            parts.append(f"{self.default_type} {self.default_expression}")
+        if self.default_expression is not None:
+            # Emit the DEFAULT/MATERIALIZED clause whenever an expression is
+            # declared; ``default_type`` defaults to ``DEFAULT`` so a column that
+            # only sets ``default_expression`` still gets its intended default.
+            default_type = self.default_type or "DEFAULT"
+            parts.append(f"{default_type} {self.default_expression}")
         if self.comment:
             parts.append(f"COMMENT {quote_identifier(self.comment)}")
         if self.codec_expression:

--- a/evnt/routers/tracker/db/clickhouse/table_manager.py
+++ b/evnt/routers/tracker/db/clickhouse/table_manager.py
@@ -27,18 +27,16 @@ class TableManager:
         """
         Create databases for all tables.
         """
-        databases = []
+        databases: set[str] = set()
 
         for group, tables in self.connector.tables.items():
-            if group not in databases:
-                databases.append(group)
+            databases.add(group)
             for table_info in tables.values():
                 if not isinstance(table_info, dict):
                     continue
                 if table_info["name"] and "." in table_info["name"]:
                     db = table_info["name"].split(".")[0]
-                    if db not in databases:
-                        databases.append(db)
+                    databases.add(db)
 
         for db in databases:
             await self.connector.command(
@@ -56,10 +54,7 @@ class TableManager:
         """
         table_data = self.connector.tables[table_group]["local"]
         fields = get_fields_for_table_group(table_group)
-
-        columns = []
-        for field in fields:
-            columns.append(field.create_expression)
+        columns = [field.create_expression for field in fields]
 
         full_table_name = await self.connector.get_full_table_name(table_data["name"])
 

--- a/evnt/routers/tracker/db/clickhouse/table_manager.py
+++ b/evnt/routers/tracker/db/clickhouse/table_manager.py
@@ -30,6 +30,8 @@ class TableManager:
         databases: set[str] = set()
 
         for group, tables in self.connector.tables.items():
+            if not isinstance(tables, dict):
+                continue
             databases.add(group)
             for table_info in tables.values():
                 if not isinstance(table_info, dict):

--- a/evnt/routers/tracker/handlers.py
+++ b/evnt/routers/tracker/handlers.py
@@ -2,6 +2,7 @@
 Core data processing handlers for Snowplow events.
 """
 
+import asyncio
 from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 
@@ -44,7 +45,7 @@ async def process_data(
         List of processed event records ready for storage
     """
     user_ip = convert_ip(user_ip)
-    ua_data = parse_agent_for_insert(user_agent)
+    ua_data = await asyncio.to_thread(parse_agent_for_insert, user_agent)
 
     # Extract payload data
     if isinstance(body, PayloadModel):

--- a/evnt/routers/tracker/models/sendgrid.py
+++ b/evnt/routers/tracker/models/sendgrid.py
@@ -4,7 +4,7 @@ Data models for Sendgrid events.
 
 from datetime import datetime
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .base import Model
 
@@ -13,6 +13,25 @@ class SendgridElementBaseModel(Model):
     """Model for Sendgrid webhook events."""
 
     email: str = Field(..., title="Email address")
+
+    @field_validator("email", mode="before")
+    @classmethod
+    def validate_email(cls, v: str) -> str:
+        """Strip whitespace and reject empty / obviously-invalid addresses.
+
+        Deliberately lenient (no full RFC validation, no extra dependency such
+        as ``EmailStr``) so genuine SendGrid webhook payloads keep parsing; we
+        only require a non-empty value containing an ``@`` separator.
+        """
+        if not isinstance(v, str):
+            raise ValueError("email must be a string")
+        email = v.strip()
+        if not email:
+            raise ValueError("email must not be empty")
+        if "@" not in email:
+            raise ValueError("email must contain '@'")
+        return email
+
     timestamp: datetime = Field(..., title="Event timestamp")
     smtp_id: str = Field(..., validation_alias="smtp-id", title="SMTP ID")
     event: str = Field(..., title="Event type")

--- a/evnt/routers/tracker/models/snowplow.py
+++ b/evnt/routers/tracker/models/snowplow.py
@@ -130,8 +130,7 @@ class Contexts(Base):
     @computed_field
     @property
     def contexts(self) -> dict[str, Any] | None:
-        contexts = find_available(self.co, self.cx)
-        return contexts
+        return find_available(self.co, self.cx)
 
     @computed_field
     @property

--- a/evnt/routers/tracker/models/snowplow.py
+++ b/evnt/routers/tracker/models/snowplow.py
@@ -32,6 +32,10 @@ _utcnow = partial(datetime.now, UTC)
 class SnowPlowModel(Model):
     """Base model for Snowplow data."""
 
+    # ``data`` is intentionally ``list[Any]`` only on this abstract base: the
+    # base is never instantiated/validated directly. Concrete subclasses tighten
+    # the element type to restore schema enforcement on the real POST body wrapper
+    # (e.g. ``PayloadModel.data: list[PayloadElementModel]`` below).
     data: list[Any] = Field(...)
     json_schema: str | None = Field(
         None,
@@ -173,7 +177,7 @@ class PayloadBase(Base, Validation, StructuredEvent):
         default_factory=_utcnow,
         title="Timestamp when event occurred, as recorded by client device",
     )
-    stm: datetime | None = Field(
+    stm: datetime = Field(
         default_factory=_utcnow,
         title="Timestamp when event was sent by client device to collector",
     )

--- a/evnt/routers/tracker/parsers/payload.py
+++ b/evnt/routers/tracker/parsers/payload.py
@@ -175,7 +175,7 @@ def parse_cookies(cookies_str: str | None) -> dict[str, Any]:
     try:
         cookies.load(cookies_str)
     except Exception as e:
-        logger.warning(f"Failed to parse cookies: {e}")
+        logger.warning("Failed to parse cookies", error=str(e))
         return {}
 
     # Extract Snowplow specific cookies
@@ -190,15 +190,10 @@ def parse_cookies(cookies_str: str | None) -> dict[str, Any]:
 
             result["device_id"] = parts[0]
             result["created_time"] = parts[1]
-            if parts[2] is not None:
-                result["vid"] = parts[2]
+            result["vid"] = parts[2]
             result["now_time"] = parts[3]
             result["last_visit_time"] = parts[4]
             result["session_id"] = parts[5]
-
-        # # Extract session ID from sp cookie
-        # if name.startswith("_sp_ses"):
-        #     result["session_id"] = cookie.value
 
     return result
 
@@ -513,7 +508,7 @@ def _apply_amp_linker(result: InsertModel) -> None:
         amp_device_id = parse_base64(amp_device_id)
         result.amp["device_id"] = UUID(amp_device_id)
     except Exception as e:
-        logger.warning(f"Failed to parse AMP linker: {e}")
+        logger.warning("Failed to parse AMP linker", error=str(e))
 
 
 def _apply_cookie_duid(result: InsertModel, cookies: str | None) -> None:

--- a/evnt/routers/tracker/parsers/payload.py
+++ b/evnt/routers/tracker/parsers/payload.py
@@ -2,6 +2,7 @@
 Payload parsing functionality for Snowplow events.
 """
 
+import asyncio
 import urllib.parse as urlparse
 from collections.abc import Callable
 from copy import copy
@@ -82,6 +83,49 @@ def _coalesce_dimension_value(value: Any, fallback: str) -> str:
     if isinstance(value, str) and value.strip():
         return value
     return fallback
+
+
+def _safe_uuid(value: Any, fallback: UUID = DEFAULT_UUID) -> UUID:
+    """Parse a tracker-supplied UUID string, falling back on malformed input.
+
+    Tracker payloads are untrusted, so a bad value must not raise and abort the
+    whole ingest. Logs a warning and returns ``fallback`` instead.
+    """
+
+    try:
+        return UUID(value)
+    except (ValueError, TypeError) as e:
+        logger.warning("Failed to parse UUID", value=value, error=str(e))
+        return fallback
+
+
+def _safe_datetime(value: Any, fallback: datetime = DEFAULT_DATE) -> datetime:
+    """Parse a tracker-supplied ISO datetime string, falling back on bad input.
+
+    Tracker payloads are untrusted, so a bad value must not raise and abort the
+    whole ingest. Logs a warning and returns ``fallback`` instead.
+    """
+
+    try:
+        return datetime.fromisoformat(value)
+    except (ValueError, TypeError) as e:
+        logger.warning("Failed to parse datetime", value=value, error=str(e))
+        return fallback
+
+
+_IGLU_SCHEME_PREFIX = "iglu:"
+
+
+def _schema_name_from_uri(schema_uri: str) -> str:
+    """Extract the ``vendor/name`` key from an Iglu schema URI.
+
+    Strips a leading ``iglu:`` scheme prefix explicitly (instead of a magic
+    numeric slice) so non-iglu URIs are not silently truncated, then keeps the
+    first two path segments (``vendor/name``).
+    """
+
+    body = schema_uri.removeprefix(_IGLU_SCHEME_PREFIX)
+    return "/".join(body.split("/")[:2])
 
 
 def _log_validation_result(
@@ -179,7 +223,7 @@ def _h_ga_cookies(model: InsertModel, data: dict[str, Any]) -> None:
 
 
 def _h_web_page(model: InsertModel, data: dict[str, Any]) -> None:
-    model.view_id = UUID(data["id"])
+    model.view_id = _safe_uuid(data.get("id"))
 
 
 def _h_amp(model: InsertModel, data: dict[str, Any]) -> None:
@@ -191,10 +235,18 @@ def _h_page_data(model: InsertModel, data: dict[str, Any]) -> None:
 
 
 def _h_mobile_context(model: InsertModel, data: dict[str, Any]) -> None:
-    model.device_brand = data.pop("deviceManufacturer")
-    model.device_model = data.pop("deviceModel")
-    model.os_family = data.pop("osType")
-    model.os_version_string = data.pop("osVersion")
+    device_brand = data.pop("deviceManufacturer", None)
+    if device_brand is not None:
+        model.device_brand = device_brand
+    device_model = data.pop("deviceModel", None)
+    if device_model is not None:
+        model.device_model = device_model
+    os_family = data.pop("osType", None)
+    if os_family is not None:
+        model.os_family = os_family
+    os_version = data.pop("osVersion", None)
+    if os_version is not None:
+        model.os_version_string = os_version
     model.device_is_mobile = True
     model.device_is_touch_capable = True
     model.device_extra = data
@@ -211,25 +263,29 @@ def _h_client_session(model: InsertModel, data: dict[str, Any]) -> None:
     if visit_count:
         model.vid = visit_count
     if data.get("sessionId"):
-        model.sid = UUID(data.pop("sessionId"))
+        model.sid = _safe_uuid(data.pop("sessionId"))
     if data.get("userId"):
-        model.duid = UUID(data.pop("userId"))
+        model.duid = _safe_uuid(data.pop("userId"))
     model.event_index = data.pop("eventIndex", 0)
     first_event_time = data.pop("firstEventTimestamp", None)
     if first_event_time is not None:
-        model.first_event_time = datetime.fromisoformat(first_event_time)
+        model.first_event_time = _safe_datetime(first_event_time)
     previous_session_id = data.pop("previousSessionId", None)
     if previous_session_id:
-        model.previous_session_id = UUID(previous_session_id)
+        model.previous_session_id = _safe_uuid(previous_session_id)
     first_event_id = data.pop("firstEventId", None)
     if first_event_id:
-        model.first_event_id = UUID(first_event_id)
+        model.first_event_id = _safe_uuid(first_event_id)
     model.storage_mechanism = data.pop("storageMechanism", "")
 
 
 def _h_mobile_screen(model: InsertModel, data: dict[str, Any]) -> None:
-    model.url = data.pop("name")
-    model.view_id = UUID(data.pop("id"))
+    name = data.pop("name", None)
+    if name is not None:
+        model.url = name
+    screen_id = data.pop("id", None)
+    if screen_id is not None:
+        model.view_id = _safe_uuid(screen_id)
     model.screen = dict(model.screen, **data)
 
 
@@ -331,7 +387,7 @@ async def parse_contexts(
         schema_uri = context["schema"]
         data = context["data"]
 
-        validation = validate_iglu_payload(schema_uri, data)
+        validation = await asyncio.to_thread(validate_iglu_payload, schema_uri, data)
         _log_validation_result(
             validation,
             schema_uri=schema_uri,
@@ -342,7 +398,7 @@ async def parse_contexts(
             logger.warning("Wrong schema type", context=context)
             continue
 
-        schema = "/".join(schema_uri[5:].split("/")[:2])
+        schema = _schema_name_from_uri(schema_uri)
 
         if not isinstance(data, dict):
             logger.warning("Wrong data type", context=context)
@@ -381,7 +437,11 @@ async def parse_event(event: dict[str, Any] | None, model: InsertModel) -> Inser
 
     event_payload: dict[str, Any] = event["data"]
     schema_uri = event_payload.get("schema", "")
-    validation = validate_iglu_payload(schema_uri, event_payload.get("data"))
+    validation = await asyncio.to_thread(
+        validate_iglu_payload,
+        schema_uri,
+        event_payload.get("data"),
+    )
     _log_validation_result(
         validation,
         schema_uri=schema_uri,
@@ -406,6 +466,10 @@ def _build_initial_model(
 ) -> InsertModel:
     """Merge payload + UA + IP into a fresh InsertModel."""
 
+    # model_construct skips validation, so document the invariant the caller
+    # must uphold: ``ip`` is an already-validated IPv4Address.
+    assert isinstance(ip, IPv4Address)
+
     data = user_agent.__dict__.copy()
     for field_name in _MUTABLE_USER_AGENT_FIELDS:
         data[field_name] = copy(data[field_name])
@@ -429,7 +493,7 @@ def _apply_amp_fields(result: InsertModel) -> None:
         result.e = "pp"
         result.ue["amp_page_ping"] = result.ue.pop("amp_page_ping")
     if result.amp.get("domainUserid"):
-        result.duid = UUID(result.amp.pop("domainUserid"))
+        result.duid = _safe_uuid(result.amp.pop("domainUserid"))
 
 
 def _apply_amp_linker(result: InsertModel) -> None:
@@ -459,7 +523,7 @@ def _apply_cookie_duid(result: InsertModel, cookies: str | None) -> None:
         return
     sp_cookies = parse_cookies(cookies)
     if sp_cookies and "device_id" in sp_cookies:
-        result.duid = UUID(sp_cookies["device_id"])
+        result.duid = _safe_uuid(sp_cookies["device_id"])
 
 
 def _apply_screen_view(result: InsertModel) -> None:
@@ -467,7 +531,7 @@ def _apply_screen_view(result: InsertModel) -> None:
 
     if "screen_view" in result.ue:
         result.e = "pv"
-        result.view_id = UUID(result.ue["screen_view"].pop("id"))
+        result.view_id = _safe_uuid(result.ue["screen_view"].pop("id"))
         result.url = result.ue["screen_view"].pop("name")
 
         if "previousName" in result.ue["screen_view"]:

--- a/evnt/routers/tracker/parsers/utils.py
+++ b/evnt/routers/tracker/parsers/utils.py
@@ -1,3 +1,5 @@
+"""Utility helpers for decoding Snowplow tracker payloads."""
+
 import base64
 
 import orjson
@@ -37,6 +39,11 @@ def find_available(
     unencoded: str | dict | None,
     encoded: str | dict | None,
 ) -> dict | None:
+    """Return the first available payload as a dict, decoding base64 if needed.
+
+    Prefers ``unencoded`` over ``encoded``. Returns ``None`` when neither
+    yields a valid JSON object.
+    """
     result = None
 
     if unencoded:

--- a/evnt/routers/tracker/routes/snowplow.py
+++ b/evnt/routers/tracker/routes/snowplow.py
@@ -30,6 +30,12 @@ async def get_user_ip_from_configured_header(
     Returns:
         Parsed IP address or None
     """
+    # Trust proxy headers contract: when proxy headers are not trusted, ignore
+    # the configured forwarding header and rely on the direct peer address only.
+    if not settings.security.trust_proxy_headers:
+        host = request.client.host if request.client else None
+        return extract_ip_from_header(host)
+
     header_name = settings.common.snowplow.user_ip_header
     for header_value in request.headers.getlist(header_name):
         parsed_ip = extract_ip_from_header(header_value)

--- a/tests/core/test_healthcheck_probe.py
+++ b/tests/core/test_healthcheck_probe.py
@@ -1,0 +1,106 @@
+"""Behavioral tests for the health probe endpoint and ClickHouse checker.
+
+``probe`` reads ``request.app.state`` for the health checker, ingest mode and
+connector, so a tiny fake request/app-state stands in for the real app. These
+cover the healthy (200 + table), unhealthy (502), and table-lookup-failure
+branches, plus ``ClickHouseHealthChecker.check`` success and failure.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from core.healthcheck import ClickHouseHealthChecker, probe
+
+
+class _FakeChecker:
+    def __init__(self, status):
+        self._status = status
+
+    async def check(self):
+        return dict(self._status)
+
+
+class _FakeConnector:
+    def __init__(self, table_name="evnt.events_local", raises=False):
+        self._table_name = table_name
+        self._raises = raises
+
+    async def get_table_name(self, table_group="evnt"):
+        if self._raises:
+            raise RuntimeError("no table")
+        return self._table_name
+
+
+def _request(checker, ingest_mode="clickhouse", connector=None):
+    state = SimpleNamespace(
+        health_checker=checker,
+        ingest_mode=ingest_mode,
+        connector=connector or _FakeConnector(),
+    )
+    return SimpleNamespace(app=SimpleNamespace(state=state))
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_probe_healthy_returns_200_with_table(anyio_backend):
+    request = _request(_FakeChecker({"clickhouse": True}))
+
+    response = await probe(request)
+
+    assert response.status_code == 200
+    assert b'"healthy":true' in response.body
+    assert b"evnt.events_local" in response.body
+    assert b'"ingest_mode":"clickhouse"' in response.body
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_probe_unhealthy_returns_502(anyio_backend):
+    request = _request(_FakeChecker({"clickhouse": False}))
+
+    response = await probe(request)
+
+    assert response.status_code == 502
+    assert b'"healthy":false' in response.body
+    # No table key is added when unhealthy.
+    assert b"events_local" not in response.body
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_probe_healthy_but_table_lookup_fails_omits_table(anyio_backend):
+    request = _request(
+        _FakeChecker({"clickhouse": True}),
+        connector=_FakeConnector(raises=True),
+    )
+
+    response = await probe(request)
+
+    assert response.status_code == 200
+    assert b'"healthy":true' in response.body
+    assert b'"table"' not in response.body
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_clickhouse_checker_reports_healthy_on_select_one(anyio_backend):
+    class _Client:
+        async def query(self, sql):
+            assert sql == "SELECT 1"
+            return SimpleNamespace(first_row=[1])
+
+    status = await ClickHouseHealthChecker(_Client()).check()
+
+    assert status == {"clickhouse": True}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_clickhouse_checker_reports_unhealthy_on_error(anyio_backend):
+    class _Client:
+        async def query(self, sql):
+            raise RuntimeError("connection refused")
+
+    status = await ClickHouseHealthChecker(_Client()).check()
+
+    assert status == {"clickhouse": False}

--- a/tests/core/test_lifespan.py
+++ b/tests/core/test_lifespan.py
@@ -1,3 +1,4 @@
+import importlib
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -220,3 +221,126 @@ async def test_lifespan_warms_iglu_schema_cache(monkeypatch, anyio_backend):
         and kwargs["skipped_count"] == 0
         for args, kwargs in logger.infos
     )
+
+
+class _FakeRabbitMQConnector:
+    """Stand-in for RabbitMQPublisher returned by ``create``."""
+
+    def __init__(self):
+        self.channel = SimpleNamespace(name="fake-channel")
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeRabbitMQHealthChecker:
+    def __init__(self, channel, *queue_names):
+        self.channel = channel
+        self.queue_names = queue_names
+
+    async def check(self):
+        return {"rabbitmq": True}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_lifespan_configures_rabbitmq_ingest(monkeypatch, anyio_backend):
+    # The RabbitMQ publisher/health-checker are imported lazily inside
+    # ``_configure_rabbitmq_ingest`` from the ``ingest`` package, so patch them
+    # on that module to avoid touching a real broker.
+    ingest_module = importlib.import_module("ingest")
+
+    connector = _FakeRabbitMQConnector()
+    create_calls = []
+
+    async def _fake_create(*, config, tables, database, cluster_name):
+        create_calls.append(
+            {
+                "config": config,
+                "tables": tables,
+                "database": database,
+                "cluster_name": cluster_name,
+            },
+        )
+        return connector
+
+    monkeypatch.setattr(
+        ingest_module.RabbitMQPublisher,
+        "create",
+        classmethod(lambda cls, **kwargs: _fake_create(**kwargs)),
+    )
+    monkeypatch.setattr(
+        ingest_module,
+        "RabbitMQHealthChecker",
+        _FakeRabbitMQHealthChecker,
+    )
+
+    async def _no_op_configure_proxy_http_client(application):
+        application.state.proxy_http_client = object()
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "_configure_proxy_http_client",
+        _no_op_configure_proxy_http_client,
+    )
+    monkeypatch.setattr(
+        lifespan_module,
+        "warm_known_iglu_schemas",
+        lambda: None,
+    )
+
+    rabbitmq_config = SimpleNamespace(
+        host="rabbitmq-host",
+        queue_name="evnt.ingest",
+        resolved_failed_queue_name="evnt.ingest.failed",
+    )
+    clickhouse_config = ClickHouseConfig()
+
+    monkeypatch.setattr(
+        lifespan_module,
+        "INGEST_CONFIG",
+        SimpleNamespace(mode="rabbitmq", rabbitmq=rabbitmq_config),
+    )
+    monkeypatch.setattr(
+        lifespan_module,
+        "CLICKHOUSE_CONFIG",
+        clickhouse_config,
+    )
+
+    application = SimpleNamespace(state=SimpleNamespace())
+
+    async with lifespan_module.lifespan(application):
+        # While the app is running, the RabbitMQ connector and health checker
+        # must be wired onto application state and registered as closeable.
+        assert application.state.ingest_mode == "rabbitmq"
+        assert application.state.ch_client is None
+        assert application.state.connector is connector
+        assert isinstance(
+            application.state.health_checker,
+            lifespan_module.CachedHealthChecker,
+        )
+        assert isinstance(
+            application.state.health_checker.checker,
+            _FakeRabbitMQHealthChecker,
+        )
+        assert connector in application.state._closeables
+        assert connector.closed is False
+
+    # Publisher.create received the configured tables/database/cluster.
+    assert len(create_calls) == 1
+    call = create_calls[0]
+    assert call["config"] is rabbitmq_config
+    assert call["tables"] == clickhouse_config.configuration.tables
+    assert call["database"] == clickhouse_config.configuration.database
+    assert call["cluster_name"] == clickhouse_config.configuration.cluster_name
+
+    # The health checker was built from the connector's channel + queue names.
+    assert application.state.health_checker.checker.channel is connector.channel
+    assert application.state.health_checker.checker.queue_names == (
+        rabbitmq_config.queue_name,
+        rabbitmq_config.resolved_failed_queue_name,
+    )
+
+    # On shutdown the connector must be closed.
+    assert connector.closed is True

--- a/tests/ingest/test_rabbitmq_heartbeat.py
+++ b/tests/ingest/test_rabbitmq_heartbeat.py
@@ -1,0 +1,37 @@
+"""Tests for the worker liveness heartbeat.
+
+The heartbeat must refresh the liveness file independently of message flow and
+the batch-flush timeout, so an idle worker configured with a large
+``batch_timeout_ms`` is never wrongly reported as dead by ``queue healthcheck``.
+"""
+
+import asyncio
+import types
+from contextlib import suppress
+
+import pytest
+from core.constants import WORKER_HEARTBEAT_SECONDS, WORKER_LIVENESS_STALE_SECONDS
+from ingest.rabbitmq import RabbitMQBatchWorker
+
+
+def test_heartbeat_interval_below_stale_threshold():
+    # Heartbeat cadence must stay strictly under the staleness threshold so the
+    # file is refreshed before the healthcheck would consider it stale.
+    assert 0 < WORKER_HEARTBEAT_SECONDS < WORKER_LIVENESS_STALE_SECONDS
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_heartbeat_loop_marks_alive_immediately(anyio_backend):
+    # The loop writes liveness before its first sleep, so the file is fresh as
+    # soon as the worker starts, regardless of the configured batch timeout.
+    marks: list[int] = []
+    worker = types.SimpleNamespace(_mark_alive=lambda: marks.append(1))
+
+    task = asyncio.create_task(RabbitMQBatchWorker._heartbeat_loop(worker))
+    await asyncio.sleep(0)  # let the loop run its first mark, then suspend on sleep
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+    assert marks == [1]

--- a/tests/ingest/test_rabbitmq_publisher.py
+++ b/tests/ingest/test_rabbitmq_publisher.py
@@ -1,0 +1,316 @@
+"""Behavioral tests for ``RabbitMQPublisher`` and worker backoff/flush paths.
+
+All RabbitMQ interaction is faked: a recording exchange/channel captures
+published messages and a fake message records ack/nack/reject so no broker or
+network is required. These cover the publisher's enqueue contract and the
+worker's per-table-group backoff, table-name resolution, and failed-queue
+publish-failure fallback that ``test_rabbitmq.py`` does not.
+"""
+
+import pytest
+from clickhouse_connect.driver.exceptions import DataError
+from core.config import RabbitMQConfig
+from ingest.rabbitmq import (
+    QueuedInsertPayload,
+    RabbitMQBatchWorker,
+    RabbitMQPublisher,
+)
+
+
+class _RecordingExchange:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.published = []
+
+    async def publish(self, message, routing_key, mandatory=True):
+        if self.fail:
+            raise RuntimeError("exchange down")
+        self.published.append(
+            {"message": message, "routing_key": routing_key, "mandatory": mandatory},
+        )
+
+
+class _RecordingChannel:
+    def __init__(self, exchange=None):
+        self.default_exchange = exchange or _RecordingExchange()
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeConnection:
+    def __init__(self):
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+class _FakeMessage:
+    def __init__(self, payload: QueuedInsertPayload, *, headers=None):
+        self.body = payload.model_dump_json().encode("utf-8")
+        self.headers = headers or {}
+        self.content_type = "application/json"
+        self.type = "evnt.insert"
+        self.acked = False
+        self.nacked = False
+        self.rejected = False
+
+    async def ack(self):
+        self.acked = True
+
+    async def nack(self, requeue=True):
+        self.nacked = requeue
+
+    async def reject(self, requeue=False):
+        self.rejected = not requeue
+
+
+def _publisher(channel=None, *, cluster_name=None):
+    return RabbitMQPublisher(
+        connection=_FakeConnection(),
+        channel=channel or _RecordingChannel(),
+        config=RabbitMQConfig(queue_name="evnt.ingest"),
+        tables={
+            "evnt": {
+                "local": {"name": "events_local"},
+                "distributed": {"name": "events_distributed"},
+            },
+        },
+        database="evnt",
+        cluster_name=cluster_name,
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_publisher_insert_rows_publishes_persistent_message(anyio_backend):
+    channel = _RecordingChannel()
+    publisher = _publisher(channel)
+
+    await publisher.insert_rows([{"aid": "a"}, {"aid": "b"}], table_group="evnt")
+
+    assert len(channel.default_exchange.published) == 1
+    published = channel.default_exchange.published[0]
+    assert published["routing_key"] == "evnt.ingest"
+    assert published["mandatory"] is True
+
+    decoded = QueuedInsertPayload.model_validate_json(published["message"].body)
+    assert decoded.table_group == "evnt"
+    assert decoded.rows == [{"aid": "a"}, {"aid": "b"}]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_publisher_insert_rows_noop_for_empty_rows(anyio_backend):
+    channel = _RecordingChannel()
+    publisher = _publisher(channel)
+
+    await publisher.insert_rows([], table_group="evnt")
+
+    assert channel.default_exchange.published == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_publisher_get_table_name_local_and_distributed(anyio_backend):
+    local_pub = _publisher(cluster_name=None)
+    cluster_pub = _publisher(cluster_name="prod")
+
+    assert await local_pub.get_table_name() == "events_local"
+    assert await cluster_pub.get_table_name() == "events_distributed"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_publisher_close_closes_channel_and_connection(anyio_backend):
+    channel = _RecordingChannel()
+    publisher = _publisher(channel)
+
+    await publisher.close()
+
+    assert channel.closed is True
+    assert publisher.connection.closed is True
+
+
+# ---------------------------------------------------------------------------
+# Worker backoff / failed-queue fallback paths
+# ---------------------------------------------------------------------------
+
+
+class _BatchSink:
+    def __init__(self, fail=False):
+        self.fail = fail
+        self.batch_calls = []
+
+    async def insert_batch(self, rows, table_group="evnt"):
+        if self.fail:
+            raise RuntimeError("boom")
+        self.batch_calls.append((table_group, rows))
+
+
+class _InsertRowsOnlySink:
+    """Sink lacking ``insert_batch`` so the worker falls back to insert_rows."""
+
+    def __init__(self):
+        self.rows_calls = []
+
+    async def insert_rows(self, rows, table_group="evnt"):
+        self.rows_calls.append((table_group, rows))
+
+
+def _worker(sink, channel=None, **overrides):
+    config_data = {"batch_size": 10, "batch_timeout_ms": 1000, "retry_delay_ms": 100}
+    config_data.update(overrides)
+    return RabbitMQBatchWorker(
+        connection=_FakeConnection(),
+        channel=channel or _RecordingChannel(),
+        queue=object(),
+        sink=sink,
+        config=RabbitMQConfig(**config_data),
+    )
+
+
+def test_backoff_seconds_grows_exponentially_and_caps():
+    worker = _worker(_BatchSink(), retry_delay_ms=1000)  # retry_delay = 1.0s
+
+    assert worker._backoff_seconds() == 0.0
+
+    worker.failure_counts["evnt"] = 1
+    assert worker._backoff_seconds() == 1.0  # 1.0 * 2**0
+
+    worker.failure_counts["evnt"] = 3
+    assert worker._backoff_seconds() == 4.0  # 1.0 * 2**2
+
+    worker.failure_counts["evnt"] = 100
+    assert worker._backoff_seconds() == RabbitMQBatchWorker.MAX_BACKOFF_SECONDS
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_flush_failure_increments_failure_count_then_resets(anyio_backend):
+    sink = _BatchSink(fail=True)
+    worker = _worker(sink)
+    msg = _FakeMessage(QueuedInsertPayload(rows=[{"id": 1}]))
+    await worker.add_message(msg)
+
+    await worker.flush_table_group("evnt")
+
+    assert worker.failure_counts["evnt"] == 1
+    assert msg.nacked is True
+
+    # Now succeed: failure count for the group is cleared.
+    sink.fail = False
+    msg2 = _FakeMessage(QueuedInsertPayload(rows=[{"id": 2}]))
+    await worker.add_message(msg2)
+    await worker.flush_table_group("evnt")
+
+    assert "evnt" not in worker.failure_counts
+    assert msg2.acked is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_worker_falls_back_to_insert_rows_when_no_insert_batch(anyio_backend):
+    sink = _InsertRowsOnlySink()
+    worker = _worker(sink)
+    msg = _FakeMessage(QueuedInsertPayload(rows=[{"id": 9}]))
+
+    await worker.add_message(msg)
+    await worker.flush_all()
+
+    assert sink.rows_calls == [("evnt", [{"id": 9}])]
+    assert msg.acked is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_isolated_data_error_publishes_to_failed_queue_with_headers(
+    anyio_backend,
+):
+    class _DataErrorSink:
+        async def insert_batch(self, rows, table_group="evnt"):
+            raise DataError("bad row")
+
+    channel = _RecordingChannel()
+    worker = _worker(_DataErrorSink(), channel=channel)
+    msg = _FakeMessage(QueuedInsertPayload(rows=[{"id": 1}]))
+
+    await worker.add_message(msg)
+    await worker.flush_table_group("evnt")
+
+    published = channel.default_exchange.published
+    assert len(published) == 1
+    assert published[0]["routing_key"] == "evnt.ingest.failed"
+    headers = published[0]["message"].headers
+    assert headers["x-evnt-source-queue"] == "evnt.ingest"
+    assert headers["x-evnt-table-group"] == "evnt"
+    assert "x-evnt-error" in headers
+    assert msg.acked is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_isolated_data_error_requeues_on_failed_queue_publish_error(
+    anyio_backend,
+):
+    class _DataErrorSink:
+        async def insert_batch(self, rows, table_group="evnt"):
+            raise DataError("bad row")
+
+    channel = _RecordingChannel(exchange=_RecordingExchange(fail=True))
+    worker = _worker(_DataErrorSink(), channel=channel)
+    msg = _FakeMessage(QueuedInsertPayload(rows=[{"id": 1}]))
+
+    await worker.add_message(msg)
+    await worker.flush_table_group("evnt")
+
+    # Could not move to failed queue, so the message is requeued and the group
+    # is marked failed (for backoff).
+    assert msg.nacked is True
+    assert msg.acked is False
+    assert worker.failure_counts["evnt"] == 1
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_add_message_rejects_invalid_payload(anyio_backend):
+    worker = _worker(_BatchSink())
+
+    class _BadMessage(_FakeMessage):
+        def __init__(self):
+            self.body = b"not-json{"
+            self.acked = False
+            self.nacked = False
+            self.rejected = False
+
+    msg = _BadMessage()
+    await worker.add_message(msg)
+
+    assert msg.rejected is True
+    assert worker.pending_batches == {}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_add_message_acks_empty_rows_without_buffering(anyio_backend):
+    worker = _worker(_BatchSink())
+    msg = _FakeMessage(QueuedInsertPayload(rows=[]))
+
+    await worker.add_message(msg)
+
+    assert msg.acked is True
+    assert worker.pending_batches == {}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_worker_close_closes_channel_and_connection(anyio_backend):
+    channel = _RecordingChannel()
+    worker = _worker(_BatchSink(), channel=channel)
+
+    await worker.close()
+
+    assert channel.closed is True
+    assert worker.connection.closed is True

--- a/tests/routers/tracker/db/clickhouse/test_ch_audit_fixes.py
+++ b/tests/routers/tracker/db/clickhouse/test_ch_audit_fixes.py
@@ -1,0 +1,108 @@
+"""Regression tests for the ClickHouse-audit fixes.
+
+Covers four behavior-preserving fixes:
+- ColumnDef.create_expression now emits a declared DEFAULT expression.
+- ClickHouseConnector._sanitize_clickhouse_value is type-aware for UUID.
+- ClickHouseConfiguration validates database/cluster_name as SQL identifiers.
+- TableManager.create_database tolerates non-dict table-group values.
+"""
+
+from uuid import UUID
+
+import pytest
+from core.config import ClickHouseConfiguration
+from routers.tracker.db.clickhouse.connector import ClickHouseConnector
+from routers.tracker.db.clickhouse.schemas.snowplow import JSON, STRING, ColumnDef
+from routers.tracker.db.clickhouse.table_manager import TableManager
+
+
+class _RecordingConnector:
+    """Minimal ClickHouseConnector stand-in capturing executed commands."""
+
+    def __init__(self, tables: dict) -> None:
+        self.tables = tables
+        self.cluster_condition = ""
+        self.cluster = None
+        self.commands: list[str] = []
+
+    async def command(self, query: str) -> None:
+        self.commands.append(query)
+
+
+def test_create_expression_emits_declared_default():
+    # A column that declares only default_expression still gets DEFAULT in DDL.
+    col = ColumnDef(payload_name="x", name="extra", type=JSON, default_expression="{}")
+    expr = col.create_expression
+    assert "DEFAULT {}" in expr
+    assert expr.startswith("`extra` JSON")
+
+
+def test_create_expression_respects_explicit_default_type():
+    col = ColumnDef(
+        payload_name=None,
+        name="app",
+        type=STRING,
+        default_type="MATERIALIZED",
+        default_expression="'evnt'",
+    )
+    assert "MATERIALIZED 'evnt'" in col.create_expression
+
+
+def test_create_expression_no_default_when_absent():
+    col = ColumnDef(payload_name=None, name="plain", type=STRING)
+    assert col.create_expression == "`plain` String"
+
+
+def test_sanitize_uuid_none_becomes_zero_uuid():
+    assert ClickHouseConnector._sanitize_clickhouse_value("UUID", None) == UUID(int=0)
+
+
+def test_sanitize_string_none_becomes_empty():
+    assert ClickHouseConnector._sanitize_clickhouse_value("String", None) == ""
+    assert (
+        ClickHouseConnector._sanitize_clickhouse_value("LowCardinality(String)", None)
+        == ""
+    )
+
+
+def test_sanitize_preserves_non_none_and_other_types():
+    existing = UUID(int=5)
+    assert ClickHouseConnector._sanitize_clickhouse_value("UUID", existing) is existing
+    # Types without an explicit zero are left as None (unchanged behavior).
+    assert ClickHouseConnector._sanitize_clickhouse_value("UInt64", None) is None
+
+
+@pytest.mark.parametrize("bad", ["evil'; DROP", "db name", "a-b", "x;y"])
+def test_configuration_rejects_non_identifier(bad):
+    with pytest.raises(ValueError):
+        ClickHouseConfiguration(cluster_name=bad)
+    with pytest.raises(ValueError):
+        ClickHouseConfiguration(database=bad)
+
+
+def test_configuration_accepts_valid_identifiers_and_empty_cluster():
+    cfg = ClickHouseConfiguration(database="my_db", cluster_name="")
+    assert cfg.database == "my_db"
+    assert cfg.cluster_name == ""
+    assert ClickHouseConfiguration(cluster_name="prod_cluster").cluster_name == (
+        "prod_cluster"
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_database_tolerates_non_dict_group(anyio_backend):
+    # A malformed non-dict group value must be skipped, not crash with
+    # AttributeError ('str' object has no attribute 'values').
+    connector = _RecordingConnector(
+        tables={
+            "evnt": {"local": {"name": "evnt.local"}},
+            "broken": "not-a-dict",
+        },
+    )
+    await TableManager(connector).create_database()
+
+    created = " ".join(connector.commands)
+    assert "CREATE DATABASE IF NOT EXISTS evnt" in created
+    # The "broken" scalar group is skipped, so its value never reaches DDL.
+    assert "not-a-dict" not in created

--- a/tests/routers/tracker/db/clickhouse/test_table_manager.py
+++ b/tests/routers/tracker/db/clickhouse/test_table_manager.py
@@ -1,0 +1,288 @@
+"""Characterization tests for the ClickHouse ``TableManager`` DDL generation.
+
+These exercise ``create_database`` / ``create_local_table`` /
+``create_distributed_table`` / ``create_all_tables`` against a *fake* connector
+that records the SQL strings passed to ``.command()`` so no real ClickHouse is
+needed. The assertions pin the exact DDL shape (ON CLUSTER handling, IF NOT
+EXISTS, column expressions, database dedup, distributed source resolution).
+"""
+
+import pytest
+from routers.tracker.db.clickhouse.schemas import register_fields
+from routers.tracker.db.clickhouse.schemas.snowplow import STRING, ColumnDef
+from routers.tracker.db.clickhouse.table_manager import TableManager
+
+
+class _FakeConnector:
+    """Records SQL strings handed to ``.command()`` without touching a DB."""
+
+    def __init__(self, cluster=None, database="evnt", tables=None):
+        self.cluster = cluster
+        self.cluster_condition = f"ON CLUSTER {cluster}" if cluster else ""
+        self.database = database
+        self.tables = tables or {}
+        self.commands: list[str] = []
+
+    async def command(self, query: str) -> None:
+        self.commands.append(query)
+
+    async def get_full_table_name(self, table_name: str) -> str:
+        if "." in table_name:
+            return table_name
+        return f"{self.database}.{table_name}"
+
+
+def _local_table(name="events_local"):
+    return {
+        "name": name,
+        "engine": "MergeTree()",
+        "partition_by": "toYYYYMM(time)",
+        "order_by": "time",
+        "sample_by": "eid",
+        "settings": "index_granularity=8192",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _register_two_string_fields():
+    """Give the ``tm_test`` group a tiny, deterministic schema."""
+
+    register_fields(
+        "tm_test",
+        [
+            ColumnDef(payload_name="foo", name="foo", type=STRING),
+            ColumnDef(payload_name="bar", name="bar", type=STRING),
+        ],
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_database_emits_if_not_exists_with_on_cluster(anyio_backend):
+    connector = _FakeConnector(
+        cluster="prod_cluster",
+        tables={"evnt": {"local": {"name": "events_local"}}},
+    )
+    manager = TableManager(connector)
+
+    await manager.create_database()
+
+    assert connector.commands == [
+        "CREATE DATABASE IF NOT EXISTS evnt ON CLUSTER prod_cluster",
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_database_without_cluster_has_no_on_cluster_clause(anyio_backend):
+    connector = _FakeConnector(
+        cluster=None,
+        tables={"evnt": {"local": {"name": "events_local"}}},
+    )
+    manager = TableManager(connector)
+
+    await manager.create_database()
+
+    # cluster_condition is empty, leaving a trailing space the code appends.
+    assert connector.commands == ["CREATE DATABASE IF NOT EXISTS evnt "]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_database_collects_qualified_table_dbs_and_dedups(anyio_backend):
+    """Group key + every ``db.table`` qualified name produce one CREATE each."""
+
+    connector = _FakeConnector(
+        cluster=None,
+        tables={
+            "evnt": {
+                "local": {"name": "analytics.events_local"},
+                "distributed": {"name": "analytics.events"},
+                # A non-dict per-table value is skipped by the inner guard.
+                "comment": "not-a-dict",
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_database()
+
+    created_dbs = sorted(
+        cmd.split("IF NOT EXISTS ")[1].split(" ")[0] for cmd in connector.commands
+    )
+    # "evnt" (group key) and "analytics" (from the qualified table names), deduped.
+    assert created_dbs == ["analytics", "evnt"]
+    assert len(connector.commands) == 2
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_local_table_emits_full_ddl_with_columns(anyio_backend):
+    connector = _FakeConnector(
+        cluster="prod_cluster",
+        database="evnt",
+        tables={"tm_test": {"local": _local_table()}},
+    )
+    manager = TableManager(connector)
+
+    await manager.create_local_table("tm_test")
+
+    assert len(connector.commands) == 1
+    ddl = connector.commands[0]
+    assert ddl.startswith(
+        "CREATE TABLE IF NOT EXISTS evnt.events_local ON CLUSTER prod_cluster ("
+    )
+    assert "`foo` String, `bar` String" in ddl
+    assert "ENGINE = MergeTree()" in ddl
+    assert "PARTITION BY toYYYYMM(time)" in ddl
+    assert "ORDER BY (time)" in ddl
+    assert "SAMPLE BY eid" in ddl
+    assert ddl.endswith("SETTINGS index_granularity=8192;")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_local_table_qualified_name_is_not_reprefixed(anyio_backend):
+    connector = _FakeConnector(
+        cluster=None,
+        database="evnt",
+        tables={"tm_test": {"local": _local_table(name="other_db.events_local")}},
+    )
+    manager = TableManager(connector)
+
+    await manager.create_local_table("tm_test")
+
+    ddl = connector.commands[0]
+    # Already-qualified name kept as-is; no ON CLUSTER (no cluster), so just a space.
+    assert ddl.startswith("CREATE TABLE IF NOT EXISTS other_db.events_local  (")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_distributed_table_uses_local_as_source(anyio_backend):
+    connector = _FakeConnector(
+        cluster="prod_cluster",
+        database="evnt",
+        tables={
+            "tm_test": {
+                "local": _local_table(),
+                "distributed": {"name": "events", "sample_by": "rand()"},
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_distributed_table("tm_test")
+
+    assert connector.commands == [
+        "CREATE TABLE IF NOT EXISTS evnt.events ON CLUSTER prod_cluster "
+        "AS evnt.events_local "
+        "ENGINE = Distributed('prod_cluster', 'evnt', 'events_local', rand());",
+    ]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_distributed_table_splits_qualified_local_source(anyio_backend):
+    connector = _FakeConnector(
+        cluster="prod_cluster",
+        database="evnt",
+        tables={
+            "tm_test": {
+                "local": _local_table(name="raw.events_local"),
+                "distributed": {"name": "events", "sample_by": "rand()"},
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_distributed_table("tm_test")
+
+    ddl = connector.commands[0]
+    assert "AS raw.events_local" in ddl
+    assert "Distributed('prod_cluster', 'raw', 'events_local', rand())" in ddl
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_distributed_table_noop_without_cluster(anyio_backend):
+    connector = _FakeConnector(
+        cluster=None,
+        tables={
+            "tm_test": {
+                "local": _local_table(),
+                "distributed": {"name": "events", "sample_by": "rand()"},
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_distributed_table("tm_test")
+
+    assert connector.commands == []
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_all_tables_creates_db_then_local_and_distributed(anyio_backend):
+    connector = _FakeConnector(
+        cluster="prod_cluster",
+        database="evnt",
+        tables={
+            "tm_test": {
+                "local": _local_table(),
+                "distributed": {"name": "events", "sample_by": "rand()"},
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_all_tables()
+
+    kinds = [cmd.split(" IF NOT EXISTS")[0] for cmd in connector.commands]
+    assert kinds == ["CREATE DATABASE", "CREATE TABLE", "CREATE TABLE"]
+    assert "AS evnt.events_local" in connector.commands[2]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_all_tables_skips_disabled_and_no_local(anyio_backend):
+    connector = _FakeConnector(
+        cluster=None,
+        database="evnt",
+        tables={
+            "disabled_group": {"local": _local_table(), "enabled": False},
+            "no_local_group": {"distributed": {"name": "x", "sample_by": "rand()"}},
+            "tm_test": {"local": _local_table()},
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_all_tables()
+
+    create_tables = [c for c in connector.commands if c.startswith("CREATE TABLE")]
+    # Only the enabled ``tm_test`` group with a "local" table produces a table.
+    assert len(create_tables) == 1
+    assert "evnt.events_local" in create_tables[0]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_create_all_tables_without_cluster_skips_distributed(anyio_backend):
+    connector = _FakeConnector(
+        cluster=None,
+        database="evnt",
+        tables={
+            "tm_test": {
+                "local": _local_table(),
+                "distributed": {"name": "events", "sample_by": "rand()"},
+            },
+        },
+    )
+    manager = TableManager(connector)
+
+    await manager.create_all_tables()
+
+    create_tables = [c for c in connector.commands if c.startswith("CREATE TABLE")]
+    assert len(create_tables) == 1
+    assert "Distributed(" not in create_tables[0]

--- a/tests/routers/tracker/models/test_base.py
+++ b/tests/routers/tracker/models/test_base.py
@@ -1,0 +1,68 @@
+"""Characterization tests for the ``Model.model_validate_json`` repair path.
+
+``Model`` overrides ``model_validate_json`` so that malformed JSON is first
+auto-repaired with ``json_repair`` before a second validation attempt. These
+tests exercise both the happy path (valid JSON parsed directly) and the repair
+fallback across ``str``/``bytes``/``bytearray``/``memoryview`` inputs, plus the
+case where even repaired JSON still fails validation.
+"""
+
+import pytest
+from pydantic import Field, ValidationError
+from routers.tracker.models.base import Model
+
+
+class _Person(Model):
+    name: str = Field(...)
+    age: int = Field(0)
+
+
+def test_valid_json_string_parses_without_repair():
+    person = _Person.model_validate_json('{"name": "Alice", "age": 30}')
+
+    assert person.name == "Alice"
+    assert person.age == 30
+
+
+def test_malformed_json_string_is_repaired():
+    # Trailing comma + single-quoted keys are invalid JSON; json_repair fixes them.
+    person = _Person.model_validate_json("{'name': 'Bob', 'age': 41,}")
+
+    assert person.name == "Bob"
+    assert person.age == 41
+
+
+def test_malformed_json_bytes_is_decoded_and_repaired():
+    person = _Person.model_validate_json(b"{name: Carol, age: 5}")
+
+    assert person.name == "Carol"
+    assert person.age == 5
+
+
+def test_malformed_json_bytearray_is_repaired():
+    person = _Person.model_validate_json(bytearray(b"{name: Dave}"))
+
+    assert person.name == "Dave"
+    assert person.age == 0
+
+
+def test_malformed_json_memoryview_is_repaired():
+    person = _Person.model_validate_json(memoryview(b"{name: Eve, age: 9}"))
+
+    assert person.name == "Eve"
+    assert person.age == 9
+
+
+def test_bytes_with_invalid_utf8_are_decoded_with_errors_ignored():
+    # 0xff is not valid UTF-8; the repair path decodes with errors="ignore".
+    person = _Person.model_validate_json(b'{"name": "F\xffrank"}')
+
+    assert person.name.startswith("F")
+    assert person.age == 0
+
+
+def test_repair_that_still_fails_validation_raises_validation_error():
+    # No way to coerce a complete missing required ``name`` field, so the
+    # second validation attempt still raises ValidationError.
+    with pytest.raises(ValidationError):
+        _Person.model_validate_json("not json at all []")

--- a/tests/routers/tracker/models/test_sendgrid.py
+++ b/tests/routers/tracker/models/test_sendgrid.py
@@ -1,0 +1,55 @@
+"""Behavioral tests for the SendGrid event model validators.
+
+Covers the lenient-but-strict ``email`` field validator (strip, non-empty,
+must contain ``@``, must be a string) and the alias mapping for ``smtp-id``.
+"""
+
+import pytest
+from pydantic import ValidationError
+from routers.tracker.models.sendgrid import SendgridElementBaseModel
+
+
+def _valid_event(**overrides):
+    base = {
+        "email": "user@example.com",
+        "timestamp": 1700000000,
+        "smtp-id": "<abc@sendgrid>",
+        "event": "delivered",
+        "category": ["welcome"],
+        "sg_event_id": "evt-1",
+        "sg_message_id": "msg-1",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_valid_event_parses_and_maps_smtp_id_alias():
+    event = SendgridElementBaseModel.model_validate(_valid_event())
+
+    assert event.email == "user@example.com"
+    assert event.smtp_id == "<abc@sendgrid>"
+    assert event.event == "delivered"
+    assert event.category == ["welcome"]
+
+
+def test_email_is_stripped_of_surrounding_whitespace():
+    event = SendgridElementBaseModel.model_validate(
+        _valid_event(email="  spaced@example.com  "),
+    )
+
+    assert event.email == "spaced@example.com"
+
+
+def test_empty_email_is_rejected():
+    with pytest.raises(ValidationError, match="email must not be empty"):
+        SendgridElementBaseModel.model_validate(_valid_event(email="   "))
+
+
+def test_email_without_at_sign_is_rejected():
+    with pytest.raises(ValidationError, match="email must contain"):
+        SendgridElementBaseModel.model_validate(_valid_event(email="not-an-email"))
+
+
+def test_non_string_email_is_rejected():
+    with pytest.raises(ValidationError, match="email must be a string"):
+        SendgridElementBaseModel.model_validate(_valid_event(email=12345))

--- a/tests/routers/tracker/parsers/test_payload_handlers.py
+++ b/tests/routers/tracker/parsers/test_payload_handlers.py
@@ -1,0 +1,484 @@
+"""Behavioral tests for Snowplow context handlers and ``_apply_*`` helpers.
+
+These run against the *real* ``InsertModel`` (loaded via the production import
+path that ``conftest.py`` enables) so the ``_h_*`` context handlers and the
+``_apply_*`` post-processing helpers are exercised end to end through
+``parse_contexts`` / ``parse_payload``. Iglu validation is monkeypatched to a
+no-op result so no network/registry is needed, and the error-guard paths (bad
+UUID / bad datetime / missing keys) are checked to fall back rather than raise.
+"""
+
+import base64
+import importlib
+from datetime import UTC, datetime
+from ipaddress import IPv4Address
+from uuid import UUID
+
+import pytest
+
+from evnt.routers.tracker.models.snowplow import (
+    PayloadElementModel,
+    UserAgentModel,
+)
+
+payload = importlib.import_module("routers.tracker.parsers.payload")
+
+DEFAULT_UUID = UUID("00000000-0000-0000-0000-000000000000")
+DEFAULT_DATE = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def _stub_iglu_validation(monkeypatch):
+    """Make Iglu validation a no-op so handlers are tested in isolation."""
+
+    monkeypatch.setattr(
+        payload,
+        "validate_iglu_payload",
+        lambda schema_uri, data: payload.ValidationResult(status="skipped"),
+    )
+
+
+def _base_model(**overrides) -> payload.InsertModel:
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "pv",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+            **overrides,
+        },
+    )
+    return payload._build_initial_model(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+    )
+
+
+def _ctx(schema_uri, data):
+    return {"data": [{"schema": schema_uri, "data": data}]}
+
+
+async def _run_contexts(schema_uri, data, **overrides):
+    model = _base_model(**overrides)
+    return await payload.parse_contexts(_ctx(schema_uri, data), model)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_web_page_context_sets_view_id(anyio_backend):
+    view_id = "11111111-1111-1111-1111-111111111111"
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
+        {"id": view_id},
+    )
+
+    assert result.view_id == UUID(view_id)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_web_page_context_bad_uuid_falls_back_to_default(anyio_backend):
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/web_page/jsonschema/1-0-0",
+        {"id": "not-a-uuid"},
+    )
+
+    assert result.view_id == DEFAULT_UUID
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_client_session_context_populates_session_fields(anyio_backend):
+    session_id = "22222222-2222-2222-2222-222222222222"
+    user_id = "33333333-3333-3333-3333-333333333333"
+    prev = "44444444-4444-4444-4444-444444444444"
+    first_event = "55555555-5555-5555-5555-555555555555"
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2",
+        {
+            "sessionIndex": 7,
+            "sessionId": session_id,
+            "userId": user_id,
+            "eventIndex": 3,
+            "firstEventTimestamp": "2024-01-02T03:04:05+00:00",
+            "previousSessionId": prev,
+            "firstEventId": first_event,
+            "storageMechanism": "LOCAL_STORAGE",
+        },
+    )
+
+    assert result.vid == 7
+    assert result.sid == UUID(session_id)
+    assert result.duid == UUID(user_id)
+    assert result.event_index == 3
+    assert result.first_event_time == datetime(2024, 1, 2, 3, 4, 5, tzinfo=UTC)
+    assert result.previous_session_id == UUID(prev)
+    assert result.first_event_id == UUID(first_event)
+    assert result.storage_mechanism == "LOCAL_STORAGE"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_client_session_bad_datetime_and_uuids_fall_back(anyio_backend):
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/client_session/jsonschema/1-0-2",
+        {
+            "sessionId": "bad-session",
+            "userId": "bad-user",
+            "firstEventTimestamp": "definitely-not-a-date",
+            "previousSessionId": "bad-prev",
+            "firstEventId": "bad-first",
+        },
+    )
+
+    assert result.sid == DEFAULT_UUID
+    assert result.duid == DEFAULT_UUID
+    assert result.first_event_time == DEFAULT_DATE
+    assert result.previous_session_id == DEFAULT_UUID
+    assert result.first_event_id == DEFAULT_UUID
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_mobile_context_maps_device_and_os_fields(anyio_backend):
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/mobile_context/jsonschema/1-0-3",
+        {
+            "deviceManufacturer": "Apple",
+            "deviceModel": "iPhone15,2",
+            "osType": "ios",
+            "osVersion": "17.4",
+            "carrier": "Verizon",
+        },
+    )
+
+    assert result.device_brand == "Apple"
+    assert result.device_model == "iPhone15,2"
+    assert result.os_family == "ios"
+    assert result.os_version_string == "17.4"
+    assert result.device_is_mobile is True
+    assert result.device_is_touch_capable is True
+    # Remaining keys survive in device_extra.
+    assert result.device_extra == {"carrier": "Verizon"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_mobile_screen_context_sets_url_and_view_id(anyio_backend):
+    screen_id = "66666666-6666-6666-6666-666666666666"
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.mobile/screen/jsonschema/1-0-0",
+        {"name": "HomeScreen", "id": screen_id, "type": "feed"},
+    )
+
+    assert result.url == "HomeScreen"
+    assert result.view_id == UUID(screen_id)
+    assert result.screen == {"type": "feed"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_amp_context_merges_into_amp_dict(anyio_backend):
+    result = await _run_contexts(
+        "iglu:dev.amp.snowplow/amp_id/jsonschema/1-0-0",
+        {"ampClientId": "amp-123", "userId": "u-1"},
+    )
+
+    assert result.amp["ampClientId"] == "amp-123"
+    assert result.amp["userId"] == "u-1"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_mobile_application_sets_app_version_and_build(anyio_backend):
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.mobile/application/jsonschema/1-0-0",
+        {"version": "2.1.0", "build": "204", "ignored": 5},
+    )
+
+    assert result.app_version == "2.1.0"
+    assert result.app_build == "204"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_static_and_performance_and_client_hints_go_to_extra(anyio_backend):
+    model = _base_model()
+    contexts = {
+        "data": [
+            {
+                "schema": "iglu:com.acme/static_context/jsonschema/1-0-0",
+                "data": {"tenant": "acme"},
+            },
+            {
+                "schema": "iglu:org.w3/PerformanceTiming/jsonschema/1-0-0",
+                "data": {"loadEventEnd": 1234},
+            },
+            {
+                "schema": "iglu:org.ietf/http_client_hints/jsonschema/1-0-0",
+                "data": {"isMobile": True},
+            },
+            {
+                "schema": "iglu:com.google.ga4/cookies/jsonschema/1-0-0",
+                "data": {"_ga": "GA1.1.x"},
+            },
+        ],
+    }
+
+    result = await payload.parse_contexts(contexts, model)
+
+    assert result.extra["tenant"] == "acme"
+    assert result.extra["performance_timing"] == {"loadEventEnd": 1234}
+    assert result.extra["client_hints"] == {"isMobile": True}
+    assert result.extra["ga_cookies"] == {"_ga": "GA1.1.x"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_geolocation_and_ue_setter_handlers(anyio_backend):
+    model = _base_model()
+    contexts = {
+        "data": [
+            {
+                "schema": (
+                    "iglu:com.snowplowanalytics.snowplow/"
+                    "geolocation_context/jsonschema/1-1-0"
+                ),
+                "data": {"latitude": 1.0, "longitude": 2.0},
+            },
+            {
+                "schema": (
+                    "iglu:com.snowplowanalytics.mobile/screen_summary/jsonschema/1-0-0"
+                ),
+                "data": {"foregroundSec": 12},
+            },
+        ],
+    }
+
+    result = await payload.parse_contexts(contexts, model)
+
+    assert result.geolocation == {"latitude": 1.0, "longitude": 2.0}
+    assert result.ue["screen_summary"] == {"foregroundSec": 12}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_browser_context_keeps_dims_and_stashes_extra(anyio_backend):
+    result = await _run_contexts(
+        "iglu:com.snowplowanalytics.snowplow/browser_context/jsonschema/2-0-0",
+        {"resolution": "800x600", "viewport": "400x300", "tabId": "t1"},
+    )
+
+    assert result.res == "800x600"
+    assert result.vp == "400x300"
+    assert result.browser_extra == {"tabId": "t1"}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_unknown_schema_is_skipped_with_warning(anyio_backend):
+    model = _base_model()
+    contexts = {
+        "data": [
+            {"schema": "iglu:com.unknown/whatever/jsonschema/1-0-0", "data": {"x": 1}},
+        ],
+    }
+
+    result = await payload.parse_contexts(contexts, model)
+
+    # Nothing crashed and no handler captured the data.
+    assert "x" not in result.extra
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_contexts_with_missing_keys_and_non_dict_are_skipped(anyio_backend):
+    model = _base_model()
+    contexts = {
+        "data": [
+            "not-a-dict",
+            {"schema": "iglu:com.acme/static_context/jsonschema/1-0-0"},  # no data
+            {"data": {"x": 1}},  # no schema
+            {
+                "schema": "iglu:com.acme/static_context/jsonschema/1-0-0",
+                "data": {"kept": True},
+            },
+        ],
+    }
+
+    result = await payload.parse_contexts(contexts, model)
+
+    # Only the well-formed static context made it through.
+    assert result.extra == {"kept": True}
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_contexts_none_or_missing_data_key_returns_model_unchanged(anyio_backend):
+    model = _base_model()
+
+    assert await payload.parse_contexts(None, model) is model
+    assert await payload.parse_contexts({"no_data": 1}, model) is model
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_non_dict_data_payload_is_skipped(anyio_backend):
+    model = _base_model()
+    contexts = {
+        "data": [
+            {
+                "schema": "iglu:com.acme/static_context/jsonschema/1-0-0",
+                "data": ["this", "is", "a", "list"],
+            },
+        ],
+    }
+
+    result = await payload.parse_contexts(contexts, model)
+
+    assert result.extra == {}
+
+
+# ---------------------------------------------------------------------------
+# _apply_* helpers exercised via parse_payload
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_parse_payload_amp_linker_extracts_device_id(anyio_backend):
+    # sp_amp_linker format: "1*<hash>*<base64 device id>".
+    device_uuid = "77777777-7777-7777-7777-777777777777"
+    encoded = base64.urlsafe_b64encode(device_uuid.encode()).decode().rstrip("=")
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "pv",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+            "url": f"https://example.com/?sp_amp_linker=1*abc*{encoded}",
+        },
+    )
+
+    result = await payload.parse_payload(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+        cookies=None,
+    )
+
+    assert result.amp["device_id"] == UUID(device_uuid)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_parse_payload_cookie_duid_fallback(anyio_backend):
+    device_id = "88888888-8888-8888-8888-888888888888"
+    cookie = (
+        "_sp_id.1234="
+        f"{device_id}.1700000000.1.1700000100.1700000050."
+        "99999999-9999-9999-9999-999999999999"
+    )
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "pv",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+        },
+    )
+
+    result = await payload.parse_payload(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+        cookies=cookie,
+    )
+
+    assert result.duid == UUID(device_id)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_parse_payload_normalizes_se_property_and_value(anyio_backend):
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "se",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+            "se_pr": "not-json-string",
+            "se_va": "12.5",
+        },
+    )
+
+    result = await payload.parse_payload(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+        cookies=None,
+    )
+
+    # Non-JSON se_pr string is wrapped under "ex-property".
+    assert result.se_pr == {"ex-property": "not-json-string"}
+    # Numeric-looking se_va string is coerced to float.
+    assert result.se_va == 12.5
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_parse_payload_non_numeric_se_value_stashed(anyio_backend):
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "se",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+            "se_va": "abc",
+        },
+    )
+
+    result = await payload.parse_payload(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+        cookies=None,
+    )
+
+    assert result.se_va == 0.0
+    assert result.se_pr.get("ex-value") == "abc"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_parse_payload_client_hints_device_flags(anyio_backend):
+    element = PayloadElementModel.model_validate(
+        {
+            "aid": "example-app",
+            "e": "pv",
+            "p": "web",
+            "tv": "js-3.0.0",
+            "res": "1920x1080",
+            "co": (
+                '{"data": [{"schema": '
+                '"iglu:org.ietf/http_client_hints/jsonschema/1-0-0", '
+                '"data": {"isMobile": true}}]}'
+            ),
+        },
+    )
+
+    result = await payload.parse_payload(
+        element,
+        UserAgentModel(),
+        IPv4Address("127.0.0.1"),
+        cookies=None,
+    )
+
+    assert result.device_is_mobile is True
+    assert result.device_is_pc is False

--- a/tests/routers/tracker/routes/test_sendgrid_route.py
+++ b/tests/routers/tracker/routes/test_sendgrid_route.py
@@ -1,0 +1,58 @@
+"""Behavioral test for the SendGrid webhook route handler.
+
+Calls ``sendgrid_event`` directly with a fake connector (RowSink) so the
+204-response contract and the row forwarding to the ``sendgrid`` table group
+are verified without HTTP plumbing or a real ClickHouse/RabbitMQ backend.
+"""
+
+import pytest
+from routers.tracker.models.sendgrid import SendgridElementBaseModel
+from routers.tracker.routes.sendgrid import sendgrid_event
+
+
+class _RecordingConnector:
+    def __init__(self):
+        self.calls = []
+
+    async def insert_rows(self, rows, table_group="evnt"):
+        self.calls.append((table_group, rows))
+
+
+def _event(email="user@example.com"):
+    return SendgridElementBaseModel.model_validate(
+        {
+            "email": email,
+            "timestamp": 1700000000,
+            "smtp-id": "<abc@sendgrid>",
+            "event": "delivered",
+            "category": ["welcome"],
+            "sg_event_id": "evt-1",
+            "sg_message_id": "msg-1",
+        },
+    )
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_sendgrid_event_forwards_rows_and_returns_204(anyio_backend):
+    connector = _RecordingConnector()
+    body = [_event("a@example.com"), _event("b@example.com")]
+
+    response = await sendgrid_event(connector, body)
+
+    assert response.status_code == 204
+    assert len(connector.calls) == 1
+    table_group, rows = connector.calls[0]
+    assert table_group == "sendgrid"
+    assert [row["email"] for row in rows] == ["a@example.com", "b@example.com"]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_sendgrid_event_empty_body_still_inserts_empty_batch(anyio_backend):
+    connector = _RecordingConnector()
+
+    response = await sendgrid_event(connector, [])
+
+    assert response.status_code == 204
+    assert connector.calls == [("sendgrid", [])]

--- a/tests/routers/tracker/test_routes_http.py
+++ b/tests/routers/tracker/test_routes_http.py
@@ -1,0 +1,159 @@
+"""HTTP-level integration tests for the Snowplow tracker endpoints.
+
+These exercise the real FastAPI routing/response-model contract for the
+POST batch endpoint and the GET tracking-pixel endpoint without needing a
+real ClickHouse/RabbitMQ backend. The app is built via ``create_app()`` with
+the production lifespan patched out (the ``_no_op_lifespan`` pattern), and the
+``DbConnector`` dependency is overridden with a fake row sink so the only thing
+under test here is the HTTP/status/response-model contract -- payload parsing
+itself is covered by the unit tests under ``tests/routers/tracker/parsers/``.
+"""
+
+import importlib
+from contextlib import asynccontextmanager
+
+from core.constants import CONTENT_TYPE_GIF, TRACKING_PIXEL
+from core.dependencies import get_db_connector
+from fastapi.testclient import TestClient
+
+POST_ENDPOINT = "/tracker"
+GET_ENDPOINT = "/i"
+HTTP_NO_CONTENT = 204
+HTTP_OK = 200
+
+
+def _reload_main_module():
+    return importlib.import_module("evnt.main")
+
+
+def _no_op_lifespan(_app):
+    @asynccontextmanager
+    async def _lifespan(_application):
+        yield
+
+    return _lifespan(_app)
+
+
+class _RecordingConnector:
+    """Fake RowSink that records the rows handed to ``insert_rows``."""
+
+    def __init__(self):
+        self.inserted_batches: list[list[dict]] = []
+
+    async def insert_rows(self, rows, table_group: str = "evnt") -> None:
+        self.inserted_batches.append(rows)
+
+    async def get_table_name(self, table_group: str = "evnt") -> str:
+        return "local"
+
+
+def _build_client(monkeypatch, app_root, connector):
+    """Create a TestClient with a no-op lifespan and an overridden connector."""
+
+    monkeypatch.chdir(app_root)
+    main_module = _reload_main_module()
+    monkeypatch.setattr(main_module, "lifespan", _no_op_lifespan)
+
+    app = main_module.create_app()
+    app.dependency_overrides[get_db_connector] = lambda: connector
+    return TestClient(app)
+
+
+def _minimal_tp2_payload() -> dict:
+    """A minimal-but-valid Snowplow tp2 batch body (required fields only)."""
+
+    return {
+        "schema": ("iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4"),
+        "data": [
+            {
+                "e": "pv",
+                "aid": "example-app",
+                "p": "web",
+                "tv": "js-3.0.0",
+                "res": "1920x1080",
+            },
+        ],
+    }
+
+
+def test_tracker_post_returns_204_and_forwards_rows(monkeypatch, app_root):
+    connector = _RecordingConnector()
+    client = _build_client(monkeypatch, app_root, connector)
+
+    with client:
+        response = client.post(POST_ENDPOINT, json=_minimal_tp2_payload())
+
+    assert response.status_code == HTTP_NO_CONTENT
+    assert response.content == b""
+    # The connector received exactly one batch with one row.
+    assert len(connector.inserted_batches) == 1
+    rows = connector.inserted_batches[0]
+    assert len(rows) == 1
+    assert rows[0]["aid"] == "example-app"
+    assert rows[0]["e"] == "pv"
+
+
+def test_tracker_get_returns_gif_pixel_and_forwards_rows(monkeypatch, app_root):
+    connector = _RecordingConnector()
+    client = _build_client(monkeypatch, app_root, connector)
+
+    with client:
+        response = client.get(
+            GET_ENDPOINT,
+            params={
+                "e": "pv",
+                "aid": "example-app",
+                "p": "web",
+                "tv": "js-3.0.0",
+                "res": "1920x1080",
+                # The GET endpoint binds PayloadElementModel via Depends(), and
+                # FastAPI surfaces fields with a default_factory (eid/dtm/stm/rtm)
+                # as required query params, so they must be supplied explicitly.
+                "eid": "00000000-0000-0000-0000-000000000000",
+                "dtm": "2024-01-01T00:00:00Z",
+                "stm": "2024-01-01T00:00:00Z",
+                "rtm": "2024-01-01T00:00:00Z",
+            },
+        )
+
+    assert response.status_code == HTTP_OK
+    assert response.headers["content-type"] == CONTENT_TYPE_GIF
+    assert response.content == TRACKING_PIXEL
+    assert len(connector.inserted_batches) == 1
+    assert connector.inserted_batches[0][0]["aid"] == "example-app"
+
+
+def test_tracker_post_with_empty_batch_inserts_no_rows(monkeypatch, app_root):
+    connector = _RecordingConnector()
+    client = _build_client(monkeypatch, app_root, connector)
+
+    with client:
+        response = client.post(
+            POST_ENDPOINT,
+            json={
+                "schema": (
+                    "iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4"
+                ),
+                "data": [],
+            },
+        )
+
+    assert response.status_code == HTTP_NO_CONTENT
+    # The handler still calls the connector, but with an empty row list.
+    assert connector.inserted_batches == [[]]
+
+
+def test_tracker_post_rejects_invalid_payload(monkeypatch, app_root):
+    connector = _RecordingConnector()
+    client = _build_client(monkeypatch, app_root, connector)
+
+    with client:
+        # Missing required fields (e.g. ``e``/``tv``) on the element.
+        response = client.post(
+            POST_ENDPOINT,
+            json={"data": [{"aid": "example-app"}]},
+        )
+
+    assert response.status_code == 422
+    # No rows should have been forwarded to the connector on a validation error.
+    assert connector.inserted_batches == []

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,6 +1,7 @@
 import importlib
 from contextlib import asynccontextmanager
 
+import pytest
 from core.config import SecurityConfig
 from fastapi.testclient import TestClient
 
@@ -25,11 +26,19 @@ def test_security_config_normalizes_cors_origins():
     assert security.cors_allowed_origins == ["https://example.com"]
 
 
-def test_security_config_defaults_to_allow_all_credentialed_cors():
+def test_security_config_defaults_to_secure_cors():
     security = SecurityConfig()
 
+    # Wildcard origins remain the default, but credentials are OFF by default so
+    # the app never reflects an arbitrary origin together with credentials.
     assert security.cors_allowed_origins == ["*"]
-    assert security.cors_allow_credentials is True
+    assert security.cors_allow_credentials is False
+
+
+def test_security_config_rejects_credentialed_wildcard():
+    # The insecure combination must fail fast at construction time.
+    with pytest.raises(ValueError):
+        SecurityConfig(cors_allowed_origins=["*"], cors_allow_credentials=True)
 
 
 def test_create_app_allows_credentialed_cors_for_explicit_origins(
@@ -65,12 +74,13 @@ def test_create_app_allows_credentialed_cors_for_explicit_origins(
     assert response.headers["access-control-allow-credentials"] == "true"
 
 
-def test_create_app_supports_credentialed_cors_with_allow_all_origins(
-    monkeypatch, app_root
-):
+def test_create_app_disables_credentials_with_allow_all_origins(monkeypatch, app_root):
     monkeypatch.chdir(app_root)
     main_module = _reload_main_module()
     monkeypatch.setattr(main_module, "lifespan", _no_op_lifespan)
+    # Set the insecure combination via attribute assignment (which bypasses the
+    # model validator) to prove create_app still refuses to grant credentials
+    # when origins are wildcarded.
     monkeypatch.setattr(main_module.settings.security, "cors_allowed_origins", ["*"])
     monkeypatch.setattr(
         main_module.settings.security,
@@ -90,8 +100,8 @@ def test_create_app_supports_credentialed_cors_with_allow_all_origins(
         )
 
     assert response.status_code == 200
-    assert response.headers["access-control-allow-origin"] == "https://example.com"
-    assert response.headers["access-control-allow-credentials"] == "true"
+    # Credentials must never be granted alongside wildcard origins.
+    assert response.headers.get("access-control-allow-credentials") != "true"
 
 
 def test_base_middleware_can_disable_access_log_and_brotli(monkeypatch, app_root):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -46,12 +46,17 @@ def _encode(value: str) -> str:
     return proxy_module._encode_url_part(value)
 
 
-def _request(proxy_client, allowed_hosts=frozenset({"example.com"})):
+def _request(
+    proxy_client,
+    allowed_hosts=frozenset({"example.com"}),
+    allowed_ports=frozenset({80, 443}),
+):
     return SimpleNamespace(
         app=SimpleNamespace(
             state=SimpleNamespace(
                 proxy_http_client=proxy_client,
                 proxy_allowed_hosts=allowed_hosts,
+                proxy_allowed_ports=allowed_ports,
             ),
         ),
     )
@@ -89,13 +94,13 @@ async def test_proxy_awaits_async_request(anyio_backend):
 
 @pytest.mark.anyio
 @pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
-async def test_proxy_allows_port_on_allowed_hostname(anyio_backend):
+async def test_proxy_allows_configured_port_on_allowed_hostname(anyio_backend):
     event = asyncio.Event()
     requested_urls: list[str] = []
     proxy_client = _DummyProxyClient(event, requested_urls)
 
     response = await proxy_module.proxy(
-        _request(proxy_client),
+        _request(proxy_client, allowed_ports=frozenset({443, 8443})),
         "https",
         _encode("example.com:8443"),
         _encode("tracker"),
@@ -105,6 +110,25 @@ async def test_proxy_allows_port_on_allowed_hostname(anyio_backend):
     assert requested_urls == ["https://example.com:8443/tracker"]
     assert response.status_code == 200
     assert await _read_streaming_response(response) == b"ok"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_proxy_rejects_port_not_in_allowlist(anyio_backend):
+    event = asyncio.Event()
+    proxy_client = _DummyProxyClient(event)
+
+    with pytest.raises(proxy_module.HTTPException) as exc_info:
+        await proxy_module.proxy(
+            _request(proxy_client),
+            "https",
+            _encode("example.com:9200"),
+            _encode("internal"),
+        )
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Proxy target port not allowed"
+    assert not event.is_set()
 
 
 @pytest.mark.anyio

--- a/tests/test_proxy_hash.py
+++ b/tests/test_proxy_hash.py
@@ -1,0 +1,74 @@
+"""Tests for the ``/proxy/hash`` endpoint (``proxy_hash``).
+
+``proxy_hash`` rewrites a third-party asset URL into a same-origin proxied URL
+when the URL's host and path match the configured proxy allowlists, and returns
+the URL unchanged otherwise. The function is called directly here (mirroring the
+direct-call style used in ``tests/test_proxy.py``); it only depends on the
+module-level proxy configuration constants, so no app/network is needed.
+"""
+
+import base64
+
+import pytest
+
+from evnt.routers import proxy as proxy_module
+from evnt.routers.proxy import models
+
+
+def _decode(value: str) -> str:
+    return base64.urlsafe_b64decode(value).decode("utf-8")
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_proxy_hash_rewrites_matching_url(anyio_backend):
+    # Host and path both match the default proxy allowlists, so the URL must be
+    # rewritten to point at the configured app hostname.
+    data = models.HashModel(url="https://google-analytics.com/analytics.js")
+
+    result = await proxy_module.proxy_hash(data)
+    result_str = str(result)
+
+    hostname = proxy_module.HOSTNAME
+    # The rewritten URL points back at the app host (http://localhost:8000).
+    assert result_str.startswith(f"{hostname.scheme}://{hostname.host}:{hostname.port}")
+    # It is routed through the proxy endpoint's /route/<scheme>/ path.
+    assert f"{proxy_module.PROXY_ENDPOINT}/route/https/" in result_str
+
+    # The encoded host and path round-trip back to the originals.
+    route_marker = f"{proxy_module.PROXY_ENDPOINT}/route/https/".lstrip("/")
+    encoded_tail = result_str.split(route_marker, 1)[1]
+    encoded_host, encoded_path = encoded_tail.split("/", 1)
+    assert _decode(encoded_host) == "google-analytics.com"
+    assert _decode(encoded_path) == "analytics.js"
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_proxy_hash_returns_original_for_non_matching_url(anyio_backend):
+    # Neither the host nor the path is on the allowlist, so the URL is returned
+    # unchanged (no proxying).
+    original = "https://example.com/some/other/script.js"
+    data = models.HashModel(url=original)
+
+    result = await proxy_module.proxy_hash(data)
+
+    assert str(result) == original
+    # It must not be rewritten through the proxy endpoint.
+    assert f"{proxy_module.PROXY_ENDPOINT}/route/" not in str(result)
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("anyio_backend", ["asyncio"], indirect=True)
+async def test_proxy_hash_rewrites_when_only_host_matches(anyio_backend):
+    # A matching host alone (with a non-allowlisted path) is still proxied,
+    # because matching the domain flips the encode flag.
+    data = models.HashModel(url="https://google-analytics.com/g/collect?v=2")
+
+    result = await proxy_module.proxy_hash(data)
+
+    assert f"{proxy_module.PROXY_ENDPOINT}/route/https/" in str(result)
+    hostname = proxy_module.HOSTNAME
+    assert str(result).startswith(
+        f"{hostname.scheme}://{hostname.host}:{hostname.port}",
+    )


### PR DESCRIPTION
…lity)

Security:
- CORS: default cors_allow_credentials to False, reject ['*']+credentials at startup via SecurityConfig validator, and never reflect credentials with wildcard origins in the middleware.
- Proxy: stop auto-following redirects (SSRF bypass) and add a configurable outbound port allowlist (ProxyConfig.allowed_ports, default 80/443).
- Secrets: ClickHouse/RabbitMQ passwords are now SecretStr; ClickHouse client construction goes through as_client_kwargs() at all call sites.
- Enforce trust_proxy_headers for client-IP extraction; disable /docs, /redoc and /openapi.json by default; drop deprecated X-XSS-Protection header.

Async & worker reliability:
- Offload sync jsonschema validation and user-agent parsing to threads so they no longer block the event loop per request.
- RabbitMQ worker: move retry sleep out of the flush path into capped exponential backoff in the run loop; open the worker channel with publisher_confirms=True to prevent silent loss on failed-queue publishes; write a liveness file (refreshed after backoff) consumed by the healthcheck.
- CLI worker: handle SIGTERM for a clean flush+close, and retry ClickHouse startup like the app lifespan.

Correctness & API:
- Guard untrusted UUID/datetime/dict-key access in the payload parser to avoid uncaught 500s.
- Register tracker POST with status_code=204 and document proxy error responses; add response model for the health probe; HashModel uses Field not Query.
- BaseMiddleware now forwards a modified Request; ElasticAPM client is built via a lazy factory instead of at import time.

Tests:
- Update CORS/proxy tests to the new secure contract and add negative tests for credentialed wildcard and disallowed proxy ports.
- Add HTTP integration tests for the tracker endpoints, a rabbitmq-mode lifespan test, and proxy_hash coverage.