### PR TITLE
fix: stop offloading sub-millisecond hot-path work to threads

### DIFF
--- a/evnt/ingest/rabbitmq.py
+++ b/evnt/ingest/rabbitmq.py
@@ -21,7 +21,6 @@ from aio_pika.abc import (
 )
 from aio_pika.exceptions import AuthenticationError, ProbableAuthenticationError
 from clickhouse_connect.driver.exceptions import DataError
-from core.concurrency import run_cpu_task
 from core.config import RabbitMQConfig
 from core.constants import WORKER_HEARTBEAT_SECONDS, WORKER_LIVENESS_PATH
 from core.protocols import RowSink
@@ -207,7 +206,7 @@ class RabbitMQPublisher:
             logger.debug("No rows to enqueue", table_group=table_group)
             return
 
-        body = await run_cpu_task(_encode_queued_insert_payload, table_group, rows)
+        body = _encode_queued_insert_payload(table_group, rows)
         message = Message(
             body=body,
             content_type="application/json",

--- a/evnt/routers/tracker/parsers/payload.py
+++ b/evnt/routers/tracker/parsers/payload.py
@@ -13,7 +13,6 @@ from uuid import UUID
 
 import orjson
 import structlog
-from core.concurrency import run_cpu_task
 from core.config import settings
 from core.tracing import async_capture_span, capture_span
 from routers.tracker.models.snowplow import (
@@ -397,7 +396,7 @@ async def parse_contexts(
         schema_uri = context["schema"]
         data = context["data"]
 
-        validation = await run_cpu_task(validate_iglu_payload, schema_uri, data)
+        validation = validate_iglu_payload(schema_uri, data)
         _log_validation_result(
             validation,
             schema_uri=schema_uri,
@@ -446,11 +445,7 @@ async def parse_event(event: dict[str, Any] | None, model: InsertModel) -> Inser
 
     event_payload: dict[str, Any] = event["data"]
     schema_uri = event_payload.get("schema", "")
-    validation = await run_cpu_task(
-        validate_iglu_payload,
-        schema_uri,
-        event_payload.get("data"),
-    )
+    validation = validate_iglu_payload(schema_uri, event_payload.get("data"))
     _log_validation_result(
         validation,
         schema_uri=schema_uri,


### PR DESCRIPTION
run_cpu_task costs ~159us per call (thread hop plus semaphore), but the work it wrapped is far cheaper: Iglu validation is ~55us and encoding a batch of 10 rows is ~20us. The context validator runs once per context per event, so a typical 15KB POST (~10 events x ~3 contexts) paid ~40 hops -- about 6ms of pure overhead per request, roughly 1.1 cores at 184 rps.

Call all three directly instead. The user-agent parse (~504us on a cache miss) still exceeds the hop cost and keeps using run_cpu_task, as does the one-off schema warm-up at startup.

Measured on a 10-event batch: parse_contexts 9.90ms -> 2.01ms.